### PR TITLE
fix: variable state save

### DIFF
--- a/Assets/Arcweave/Demo/ArcweavePlayer.cs
+++ b/Assets/Arcweave/Demo/ArcweavePlayer.cs
@@ -77,16 +77,16 @@ namespace Arcweave
         public void Save() {
             var id = currentElement.Id;
             var variables = aw.Project.SaveVariables();
-            var save = string.Join("^", id, variables);
-            PlayerPrefs.SetString(SAVE_KEY, save);
+            PlayerPrefs.SetString(SAVE_KEY+"_currentElement", id);
+            PlayerPrefs.SetString(SAVE_KEY+"_variables", variables);
         }
 
         ///Loads the prviously current element and the variables and moves Next to that element.
         public void Load() {
-            var save = PlayerPrefs.GetString(SAVE_KEY);
-            var split = save.Split('^');
-            var element = aw.Project.ElementWithId(split[0]);
-            aw.Project.LoadVariables(split[1]);
+            var id = PlayerPrefs.GetString(SAVE_KEY+"_currentElement");
+            var variables = PlayerPrefs.GetString(SAVE_KEY+"_variables");
+            var element = aw.Project.ElementWithId(id);
+            aw.Project.LoadVariables(variables);
             Next(element);
         }
     }

--- a/Assets/Arcweave/Plugin/Runtime/Project/Project.cs
+++ b/Assets/Arcweave/Plugin/Runtime/Project/Project.cs
@@ -106,30 +106,25 @@ namespace Arcweave.Project
         }
 
         ///<summary>Returns a string of the saved variables that can be loaded later.</summary>
-        public string SaveVariables() {
-            var list = new List<string>();
-            foreach ( var variable in Variables ) {
-                list.Add(string.Format("{0}-{1}-{2}", variable.Name, variable.Value.ToString(), variable.Type.FullName));
-            }
-            var save = string.Join("|", list);
-            return save;
+        public string SaveVariables()
+        {
+            var state = new State(Variables);
+            return state.ToJson();
         }
 
         ///<summary>Loads a previously saved string made with SaveVariables.</summary>
-        public void LoadVariables(string save) {
-            var list = save.Split('|');
-            foreach ( var s in list ) {
-                var split = s.Split('-');
-                var sName = split[0];
-                var sValue = split[1];
-                var sType = split[2];
-                var type = System.Type.GetType(sType);
+        public void LoadVariables(string save)
+        {
+            State.VariableState[] variableStates = State.FromJson(save).GetVariables();
+            foreach (var variableState in variableStates)
+            {
+                var type = System.Type.GetType(variableState.type);
                 object value = null;
-                if ( type == typeof(string) ) { value = sValue; }
-                if ( type == typeof(int) ) { value = int.Parse(sValue); }
-                if ( type == typeof(float) ) { value = float.Parse(sValue); }
-                if ( type == typeof(bool) ) { value = bool.Parse(sValue); }
-                SetVariable(sName, value);
+                if (type == typeof(string)) { value = variableState.value; }
+                if ( type == typeof(int) ) { value = int.Parse(variableState.value); }
+                if ( type == typeof(float) ) { value = float.Parse(variableState.value); }
+                if ( type == typeof(bool) ) { value = bool.Parse(variableState.value); }
+                SetVariable(variableState.name, value);
             }
         }
     }

--- a/Assets/Arcweave/Plugin/Runtime/Project/State.cs
+++ b/Assets/Arcweave/Plugin/Runtime/Project/State.cs
@@ -1,0 +1,56 @@
+﻿using System;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace Arcweave.Project
+{
+    [Serializable]
+    internal class State
+    {
+        [Serializable]
+        internal struct VariableState
+        {
+            public string name;
+            public string value;
+            public string type;
+        };
+
+        [SerializeField] private VariableState[] variables;
+
+        public State() {}
+
+        public State(List<Variable> variables)
+        {
+            SetState(variables);
+        }
+        
+        public void SetState(List<Variable> vars)
+        {
+            variables = new VariableState[vars.Count];
+            int i = 0;
+            foreach (var variable in vars)
+            {
+                variables[i].name = variable.Name;
+                variables[i].value = variable.Value.ToString();
+                variables[i].type = variable.Type.FullName;
+                i++;
+            }
+        }
+
+        public string ToJson()
+        {
+            return JsonUtility.ToJson(this);
+        }
+
+        public static State FromJson(string json)
+        {
+            var state = JsonUtility.FromJson<State>(json);
+            return state;
+        }
+
+        public VariableState[] GetVariables()
+        {
+            return variables;
+        }
+    }
+}

--- a/Assets/Arcweave/Plugin/Runtime/Project/State.cs.meta
+++ b/Assets/Arcweave/Plugin/Runtime/Project/State.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 0dda8db60a2d4c9c8150e142317aa016
+timeCreated: 1709801272


### PR DESCRIPTION
This PR fixes an issue regarding saving the variable state and closes PR #3 with a better implementation that wouldn't create conflicts regardless the variable values.

We are making use of Unity's `JsonUtility` to serialize the variable state into strings.