### PR TITLE
fix: parse element title from interpreter for path resolve

### DIFF
--- a/Assets/Arcweave/Plugin/Runtime/Project/Element.cs
+++ b/Assets/Arcweave/Plugin/Runtime/Project/Element.cs
@@ -39,7 +39,12 @@ namespace Arcweave.Project
 
         void INode.InitializeInProject(Project project) { Project = project; }
         Path INode.ResolvePath(Path p) {
-            if ( string.IsNullOrEmpty(p.label) ) { p.label = Title; }
+            if (string.IsNullOrEmpty(p.label))
+            {
+                var i = new AwInterpreter(Project, Id);
+                var output = i.RunScript(Title);
+                p.label = Utils.CleanString(output.Output);
+            }
             p.TargetElement = this;
             return p;
         }


### PR DESCRIPTION
This PR fixes an issue where when the Element title is used for an option, it is not parsed from the interpreter.