### PR TITLE
fix: string concat & evaluation order

### DIFF
--- a/Assets/Arcweave/Plugin/Runtime/Interpreter/ArcscriptExpression.cs
+++ b/Assets/Arcweave/Plugin/Runtime/Interpreter/ArcscriptExpression.cs
@@ -30,7 +30,17 @@ namespace Arcweave.Interpreter
         {
             if (first.Type() == typeof(string) || second.Type() == typeof(string))
             {
-                return new Expression(first.Value.ToString() + second.Value.ToString());
+                var val1 = first.Value;
+                var val2 = second.Value;
+                if (first.Type() == typeof(bool))
+                {
+                    val1 = ((bool)first.Value) ? "true" : "false";
+                }
+                if (second.Type() == typeof(bool))
+                {
+                    val2 = ((bool)second.Value) ? "true" : "false";
+                }
+                return new Expression(val1.ToString() + val2.ToString());
             }
             var doubleValues = GetDoubleValues(first.Value, second.Value);
             if (!doubleValues.HasDouble)

--- a/Assets/Arcweave/Plugin/Runtime/Interpreter/ArcscriptVisitor.cs
+++ b/Assets/Arcweave/Plugin/Runtime/Interpreter/ArcscriptVisitor.cs
@@ -262,33 +262,31 @@ namespace Arcweave.Interpreter
         }
 
         public override object VisitAdditive_numeric_expression([NotNull] ArcscriptParser.Additive_numeric_expressionContext context) {
-            Expression mult_num_expression = (Expression)this.VisitMultiplicative_numeric_expression(context.multiplicative_numeric_expression());
-
             if ( context.additive_numeric_expression() != null ) {
                 Expression result = (Expression)this.VisitAdditive_numeric_expression(context.additive_numeric_expression());
+                Expression mult_num_expression = (Expression)this.VisitMultiplicative_numeric_expression(context.multiplicative_numeric_expression());
                 if ( context.ADD() != null ) {
-                    return mult_num_expression + result;
+                    return result + mult_num_expression;
                 }
                 // Else MINUS
-                return mult_num_expression - result;
+                return result - mult_num_expression;
             }
 
-            return mult_num_expression;
+            return (Expression)this.VisitMultiplicative_numeric_expression(context.multiplicative_numeric_expression());
         }
 
         public override object VisitMultiplicative_numeric_expression([NotNull] ArcscriptParser.Multiplicative_numeric_expressionContext context) {
-            Expression signed_unary_num_expr = (Expression)this.VisitSigned_unary_numeric_expression(context.signed_unary_numeric_expression());
-
             if ( context.multiplicative_numeric_expression() != null ) {
                 Expression result = (Expression)this.VisitMultiplicative_numeric_expression(context.multiplicative_numeric_expression());
+                Expression signed_unary_num_expr = (Expression)this.VisitSigned_unary_numeric_expression(context.signed_unary_numeric_expression());
                 if ( context.MUL() != null ) {
-                    return signed_unary_num_expr * result;
+                    return result * signed_unary_num_expr;
                 }
                 // Else DIV
-                return signed_unary_num_expr / result;
+                return result / signed_unary_num_expr;
             }
 
-            return signed_unary_num_expr;
+            return (Expression)this.VisitSigned_unary_numeric_expression(context.signed_unary_numeric_expression());
         }
 
         public override object VisitSigned_unary_numeric_expression([NotNull] ArcscriptParser.Signed_unary_numeric_expressionContext context) {
@@ -315,6 +313,14 @@ namespace Arcweave.Interpreter
             if ( context.VARIABLE() != null ) {
                 string variableName = context.VARIABLE().GetText();
                 return new Expression(this.state.GetVarValue(variableName));
+            }
+            if ( context.STRING() != null ) {
+                string result = context.STRING().GetText();
+                result = result.Substring(1, result.Length - 2);
+                return new Expression(result);
+            }
+            if ( context.BOOLEAN() != null ) {
+                return new Expression(context.BOOLEAN().GetText() == "true");
             }
 
             if ( context.function_call() != null )

--- a/Assets/Arcweave/Plugin/Runtime/Interpreter/Generated/ArcscriptParser.cs
+++ b/Assets/Arcweave/Plugin/Runtime/Interpreter/Generated/ArcscriptParser.cs
@@ -1328,36 +1328,28 @@ public partial class ArcscriptParser : ArcscriptParserBase {
 		try {
 			State = 198;
 			ErrorHandler.Sync(this);
-			switch (TokenStream.LA(1)) {
-			case FLOAT:
-			case INTEGER:
-			case LPAREN:
-			case ADD:
-			case SUB:
-			case FNAME:
-			case VARIABLE:
+			switch ( Interpreter.AdaptivePredict(TokenStream,12,Context) ) {
+			case 1:
 				EnterOuterAlt(_localctx, 1);
 				{
 				State = 195;
-				additive_numeric_expression();
+				additive_numeric_expression(0);
 				}
 				break;
-			case STRING:
+			case 2:
 				EnterOuterAlt(_localctx, 2);
 				{
 				State = 196;
 				Match(STRING);
 				}
 				break;
-			case MENTION_TAG_OPEN:
+			case 3:
 				EnterOuterAlt(_localctx, 3);
 				{
 				State = 197;
 				mention();
 				}
 				break;
-			default:
-				throw new NoViableAltException(this);
 			}
 		}
 		catch (RecognitionException re) {
@@ -1440,7 +1432,8 @@ public partial class ArcscriptParser : ArcscriptParserBase {
 			State = 212;
 			Match(MENTION_TAG_CLOSE);
 			State = 213;
-			if (!(this.assertMention(_localctx._attr))) throw new FailedPredicateException(this, "this.assertMention($attr)");
+			if (!(this.assertMention(_localctx._attr)
+					)) throw new FailedPredicateException(this, "this.assertMention($attr)\n\t\t");
 			}
 		}
 		catch (RecognitionException re) {
@@ -1530,33 +1523,58 @@ public partial class ArcscriptParser : ArcscriptParserBase {
 
 	[RuleVersion(0)]
 	public Additive_numeric_expressionContext additive_numeric_expression() {
-		Additive_numeric_expressionContext _localctx = new Additive_numeric_expressionContext(Context, State);
-		EnterRule(_localctx, 46, RULE_additive_numeric_expression);
+		return additive_numeric_expression(0);
+	}
+
+	private Additive_numeric_expressionContext additive_numeric_expression(int _p) {
+		ParserRuleContext _parentctx = Context;
+		int _parentState = State;
+		Additive_numeric_expressionContext _localctx = new Additive_numeric_expressionContext(Context, _parentState);
+		Additive_numeric_expressionContext _prevctx = _localctx;
+		int _startState = 46;
+		EnterRecursionRule(_localctx, 46, RULE_additive_numeric_expression, _p);
 		int _la;
 		try {
+			int _alt;
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 220;
-			multiplicative_numeric_expression();
-			State = 223;
-			ErrorHandler.Sync(this);
-			_la = TokenStream.LA(1);
-			if (_la==ADD || _la==SUB) {
-				{
-				State = 221;
-				_la = TokenStream.LA(1);
-				if ( !(_la==ADD || _la==SUB) ) {
-				ErrorHandler.RecoverInline(this);
-				}
-				else {
-					ErrorHandler.ReportMatch(this);
-				    Consume();
-				}
-				State = 222;
-				additive_numeric_expression();
-				}
+			{
+			State = 221;
+			multiplicative_numeric_expression(0);
 			}
-
+			Context.Stop = TokenStream.LT(-1);
+			State = 228;
+			ErrorHandler.Sync(this);
+			_alt = Interpreter.AdaptivePredict(TokenStream,16,Context);
+			while ( _alt!=2 && _alt!=global::Antlr4.Runtime.Atn.ATN.INVALID_ALT_NUMBER ) {
+				if ( _alt==1 ) {
+					if ( ParseListeners!=null )
+						TriggerExitRuleEvent();
+					_prevctx = _localctx;
+					{
+					{
+					_localctx = new Additive_numeric_expressionContext(_parentctx, _parentState);
+					PushNewRecursionContext(_localctx, _startState, RULE_additive_numeric_expression);
+					State = 223;
+					if (!(Precpred(Context, 1))) throw new FailedPredicateException(this, "Precpred(Context, 1)");
+					State = 224;
+					_la = TokenStream.LA(1);
+					if ( !(_la==ADD || _la==SUB) ) {
+					ErrorHandler.RecoverInline(this);
+					}
+					else {
+						ErrorHandler.ReportMatch(this);
+					    Consume();
+					}
+					State = 225;
+					multiplicative_numeric_expression(0);
+					}
+					} 
+				}
+				State = 230;
+				ErrorHandler.Sync(this);
+				_alt = Interpreter.AdaptivePredict(TokenStream,16,Context);
+			}
 			}
 		}
 		catch (RecognitionException re) {
@@ -1565,7 +1583,7 @@ public partial class ArcscriptParser : ArcscriptParserBase {
 			ErrorHandler.Recover(this, re);
 		}
 		finally {
-			ExitRule();
+			UnrollRecursionContexts(_parentctx);
 		}
 		return _localctx;
 	}
@@ -1594,33 +1612,58 @@ public partial class ArcscriptParser : ArcscriptParserBase {
 
 	[RuleVersion(0)]
 	public Multiplicative_numeric_expressionContext multiplicative_numeric_expression() {
-		Multiplicative_numeric_expressionContext _localctx = new Multiplicative_numeric_expressionContext(Context, State);
-		EnterRule(_localctx, 48, RULE_multiplicative_numeric_expression);
+		return multiplicative_numeric_expression(0);
+	}
+
+	private Multiplicative_numeric_expressionContext multiplicative_numeric_expression(int _p) {
+		ParserRuleContext _parentctx = Context;
+		int _parentState = State;
+		Multiplicative_numeric_expressionContext _localctx = new Multiplicative_numeric_expressionContext(Context, _parentState);
+		Multiplicative_numeric_expressionContext _prevctx = _localctx;
+		int _startState = 48;
+		EnterRecursionRule(_localctx, 48, RULE_multiplicative_numeric_expression, _p);
 		int _la;
 		try {
+			int _alt;
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 225;
+			{
+			State = 232;
 			signed_unary_numeric_expression();
-			State = 228;
-			ErrorHandler.Sync(this);
-			_la = TokenStream.LA(1);
-			if (_la==MUL || _la==DIV) {
-				{
-				State = 226;
-				_la = TokenStream.LA(1);
-				if ( !(_la==MUL || _la==DIV) ) {
-				ErrorHandler.RecoverInline(this);
-				}
-				else {
-					ErrorHandler.ReportMatch(this);
-				    Consume();
-				}
-				State = 227;
-				multiplicative_numeric_expression();
-				}
 			}
-
+			Context.Stop = TokenStream.LT(-1);
+			State = 239;
+			ErrorHandler.Sync(this);
+			_alt = Interpreter.AdaptivePredict(TokenStream,17,Context);
+			while ( _alt!=2 && _alt!=global::Antlr4.Runtime.Atn.ATN.INVALID_ALT_NUMBER ) {
+				if ( _alt==1 ) {
+					if ( ParseListeners!=null )
+						TriggerExitRuleEvent();
+					_prevctx = _localctx;
+					{
+					{
+					_localctx = new Multiplicative_numeric_expressionContext(_parentctx, _parentState);
+					PushNewRecursionContext(_localctx, _startState, RULE_multiplicative_numeric_expression);
+					State = 234;
+					if (!(Precpred(Context, 1))) throw new FailedPredicateException(this, "Precpred(Context, 1)");
+					State = 235;
+					_la = TokenStream.LA(1);
+					if ( !(_la==MUL || _la==DIV) ) {
+					ErrorHandler.RecoverInline(this);
+					}
+					else {
+						ErrorHandler.ReportMatch(this);
+					    Consume();
+					}
+					State = 236;
+					signed_unary_numeric_expression();
+					}
+					} 
+				}
+				State = 241;
+				ErrorHandler.Sync(this);
+				_alt = Interpreter.AdaptivePredict(TokenStream,17,Context);
+			}
 			}
 		}
 		catch (RecognitionException re) {
@@ -1629,7 +1672,7 @@ public partial class ArcscriptParser : ArcscriptParserBase {
 			ErrorHandler.Recover(this, re);
 		}
 		finally {
-			ExitRule();
+			UnrollRecursionContexts(_parentctx);
 		}
 		return _localctx;
 	}
@@ -1659,27 +1702,29 @@ public partial class ArcscriptParser : ArcscriptParserBase {
 		Signed_unary_numeric_expressionContext _localctx = new Signed_unary_numeric_expressionContext(Context, State);
 		EnterRule(_localctx, 50, RULE_signed_unary_numeric_expression);
 		try {
-			State = 234;
+			State = 246;
 			ErrorHandler.Sync(this);
 			switch (TokenStream.LA(1)) {
 			case ADD:
 			case SUB:
 				EnterOuterAlt(_localctx, 1);
 				{
-				State = 230;
+				State = 242;
 				sign();
-				State = 231;
+				State = 243;
 				unary_numeric_expression();
 				}
 				break;
 			case FLOAT:
 			case INTEGER:
 			case LPAREN:
+			case BOOLEAN:
 			case FNAME:
+			case STRING:
 			case VARIABLE:
 				EnterOuterAlt(_localctx, 2);
 				{
-				State = 233;
+				State = 245;
 				unary_numeric_expression();
 				}
 				break;
@@ -1703,6 +1748,8 @@ public partial class ArcscriptParser : ArcscriptParserBase {
 		[System.Diagnostics.DebuggerNonUserCode] public ITerminalNode FLOAT() { return GetToken(ArcscriptParser.FLOAT, 0); }
 		[System.Diagnostics.DebuggerNonUserCode] public ITerminalNode VARIABLE() { return GetToken(ArcscriptParser.VARIABLE, 0); }
 		[System.Diagnostics.DebuggerNonUserCode] public ITerminalNode INTEGER() { return GetToken(ArcscriptParser.INTEGER, 0); }
+		[System.Diagnostics.DebuggerNonUserCode] public ITerminalNode STRING() { return GetToken(ArcscriptParser.STRING, 0); }
+		[System.Diagnostics.DebuggerNonUserCode] public ITerminalNode BOOLEAN() { return GetToken(ArcscriptParser.BOOLEAN, 0); }
 		[System.Diagnostics.DebuggerNonUserCode] public Function_callContext function_call() {
 			return GetRuleContext<Function_callContext>(0);
 		}
@@ -1729,20 +1776,20 @@ public partial class ArcscriptParser : ArcscriptParserBase {
 		Unary_numeric_expressionContext _localctx = new Unary_numeric_expressionContext(Context, State);
 		EnterRule(_localctx, 52, RULE_unary_numeric_expression);
 		try {
-			State = 245;
+			State = 259;
 			ErrorHandler.Sync(this);
 			switch (TokenStream.LA(1)) {
 			case FLOAT:
 				EnterOuterAlt(_localctx, 1);
 				{
-				State = 236;
+				State = 248;
 				Match(FLOAT);
 				}
 				break;
 			case VARIABLE:
 				EnterOuterAlt(_localctx, 2);
 				{
-				State = 237;
+				State = 249;
 				_localctx._VARIABLE = Match(VARIABLE);
 				this.assertVariable(_localctx._VARIABLE);
 				}
@@ -1750,25 +1797,39 @@ public partial class ArcscriptParser : ArcscriptParserBase {
 			case INTEGER:
 				EnterOuterAlt(_localctx, 3);
 				{
-				State = 239;
+				State = 251;
 				Match(INTEGER);
 				}
 				break;
-			case FNAME:
+			case STRING:
 				EnterOuterAlt(_localctx, 4);
 				{
-				State = 240;
+				State = 252;
+				Match(STRING);
+				}
+				break;
+			case BOOLEAN:
+				EnterOuterAlt(_localctx, 5);
+				{
+				State = 253;
+				Match(BOOLEAN);
+				}
+				break;
+			case FNAME:
+				EnterOuterAlt(_localctx, 6);
+				{
+				State = 254;
 				function_call();
 				}
 				break;
 			case LPAREN:
-				EnterOuterAlt(_localctx, 5);
+				EnterOuterAlt(_localctx, 7);
 				{
-				State = 241;
+				State = 255;
 				Match(LPAREN);
-				State = 242;
+				State = 256;
 				compound_condition_or();
-				State = 243;
+				State = 257;
 				Match(RPAREN);
 				}
 				break;
@@ -1817,21 +1878,21 @@ public partial class ArcscriptParser : ArcscriptParserBase {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 247;
+			State = 261;
 			_localctx._FNAME = Match(FNAME);
-			State = 248;
+			State = 262;
 			Match(LPAREN);
-			State = 250;
+			State = 264;
 			ErrorHandler.Sync(this);
 			_la = TokenStream.LA(1);
-			if ((((_la) & ~0x3f) == 0 && ((1L << _la) & 3378249501554688L) != 0)) {
+			if ((((_la) & ~0x3f) == 0 && ((1L << _la) & 3378524379461632L) != 0)) {
 				{
-				State = 249;
+				State = 263;
 				_localctx._argument_list = argument_list();
 				}
 			}
 
-			State = 252;
+			State = 266;
 			Match(RPAREN);
 			this.assertFunctionArguments(_localctx._FNAME, _localctx._argument_list);
 			}
@@ -1881,27 +1942,27 @@ public partial class ArcscriptParser : ArcscriptParserBase {
 		EnterRule(_localctx, 56, RULE_void_function_call);
 		int _la;
 		try {
-			State = 269;
+			State = 283;
 			ErrorHandler.Sync(this);
 			switch (TokenStream.LA(1)) {
 			case VFNAME:
 				EnterOuterAlt(_localctx, 1);
 				{
-				State = 255;
+				State = 269;
 				_localctx._VFNAME = Match(VFNAME);
-				State = 256;
+				State = 270;
 				Match(LPAREN);
-				State = 258;
+				State = 272;
 				ErrorHandler.Sync(this);
 				_la = TokenStream.LA(1);
-				if ((((_la) & ~0x3f) == 0 && ((1L << _la) & 3378249501554688L) != 0)) {
+				if ((((_la) & ~0x3f) == 0 && ((1L << _la) & 3378524379461632L) != 0)) {
 					{
-					State = 257;
+					State = 271;
 					_localctx._argument_list = argument_list();
 					}
 				}
 
-				State = 260;
+				State = 274;
 				Match(RPAREN);
 				this.assertFunctionArguments(_localctx._VFNAME, _localctx._argument_list);
 				}
@@ -1909,23 +1970,24 @@ public partial class ArcscriptParser : ArcscriptParserBase {
 			case VFNAMEVARS:
 				EnterOuterAlt(_localctx, 2);
 				{
-				State = 262;
+				State = 276;
 				_localctx._VFNAMEVARS = Match(VFNAMEVARS);
-				State = 263;
+				State = 277;
 				Match(LPAREN);
-				State = 265;
+				State = 279;
 				ErrorHandler.Sync(this);
 				_la = TokenStream.LA(1);
 				if (_la==VARIABLE) {
 					{
-					State = 264;
+					State = 278;
 					_localctx._variable_list = variable_list();
 					}
 				}
 
-				State = 267;
+				State = 281;
 				Match(RPAREN);
 				this.assertFunctionArguments(_localctx._VFNAMEVARS, _localctx._variable_list);
+						
 				}
 				break;
 			default:
@@ -1967,7 +2029,7 @@ public partial class ArcscriptParser : ArcscriptParserBase {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 271;
+			State = 285;
 			_la = TokenStream.LA(1);
 			if ( !(_la==ADD || _la==SUB) ) {
 			ErrorHandler.RecoverInline(this);
@@ -2020,21 +2082,21 @@ public partial class ArcscriptParser : ArcscriptParserBase {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 273;
+			State = 287;
 			_localctx._VARIABLE = Match(VARIABLE);
-			State = 278;
+			State = 292;
 			ErrorHandler.Sync(this);
 			_la = TokenStream.LA(1);
 			while (_la==COMMA) {
 				{
 				{
-				State = 274;
+				State = 288;
 				Match(COMMA);
-				State = 275;
+				State = 289;
 				_localctx._VARIABLE = Match(VARIABLE);
 				}
 				}
-				State = 280;
+				State = 294;
 				ErrorHandler.Sync(this);
 				_la = TokenStream.LA(1);
 			}
@@ -2082,14 +2144,14 @@ public partial class ArcscriptParser : ArcscriptParserBase {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 283;
+			State = 297;
 			compound_condition_and();
-			State = 286;
+			State = 300;
 			ErrorHandler.Sync(this);
 			_la = TokenStream.LA(1);
 			if (_la==OR || _la==ORKEYWORD) {
 				{
-				State = 284;
+				State = 298;
 				_la = TokenStream.LA(1);
 				if ( !(_la==OR || _la==ORKEYWORD) ) {
 				ErrorHandler.RecoverInline(this);
@@ -2098,7 +2160,7 @@ public partial class ArcscriptParser : ArcscriptParserBase {
 					ErrorHandler.ReportMatch(this);
 				    Consume();
 				}
-				State = 285;
+				State = 299;
 				compound_condition_or();
 				}
 			}
@@ -2146,14 +2208,14 @@ public partial class ArcscriptParser : ArcscriptParserBase {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 288;
+			State = 302;
 			negated_unary_condition();
-			State = 291;
+			State = 305;
 			ErrorHandler.Sync(this);
 			_la = TokenStream.LA(1);
 			if (_la==AND || _la==ANDKEYWORD) {
 				{
-				State = 289;
+				State = 303;
 				_la = TokenStream.LA(1);
 				if ( !(_la==AND || _la==ANDKEYWORD) ) {
 				ErrorHandler.RecoverInline(this);
@@ -2162,7 +2224,7 @@ public partial class ArcscriptParser : ArcscriptParserBase {
 					ErrorHandler.ReportMatch(this);
 				    Consume();
 				}
-				State = 290;
+				State = 304;
 				compound_condition_and();
 				}
 			}
@@ -2207,12 +2269,12 @@ public partial class ArcscriptParser : ArcscriptParserBase {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 294;
+			State = 308;
 			ErrorHandler.Sync(this);
 			_la = TokenStream.LA(1);
 			if (_la==NEG || _la==NOTKEYWORD) {
 				{
-				State = 293;
+				State = 307;
 				_la = TokenStream.LA(1);
 				if ( !(_la==NEG || _la==NOTKEYWORD) ) {
 				ErrorHandler.RecoverInline(this);
@@ -2224,7 +2286,7 @@ public partial class ArcscriptParser : ArcscriptParserBase {
 				}
 			}
 
-			State = 296;
+			State = 310;
 			unary_condition();
 			}
 		}
@@ -2263,7 +2325,7 @@ public partial class ArcscriptParser : ArcscriptParserBase {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 298;
+			State = 312;
 			condition();
 			}
 		}
@@ -2309,16 +2371,16 @@ public partial class ArcscriptParser : ArcscriptParserBase {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 300;
+			State = 314;
 			expression();
-			State = 304;
+			State = 318;
 			ErrorHandler.Sync(this);
 			_la = TokenStream.LA(1);
 			if ((((_la) & ~0x3f) == 0 && ((1L << _la) & 281477090639872L) != 0)) {
 				{
-				State = 301;
+				State = 315;
 				conditional_operator();
-				State = 302;
+				State = 316;
 				expression();
 				}
 			}
@@ -2363,64 +2425,64 @@ public partial class ArcscriptParser : ArcscriptParserBase {
 		Conditional_operatorContext _localctx = new Conditional_operatorContext(Context, State);
 		EnterRule(_localctx, 72, RULE_conditional_operator);
 		try {
-			State = 315;
+			State = 329;
 			ErrorHandler.Sync(this);
 			switch ( Interpreter.AdaptivePredict(TokenStream,29,Context) ) {
 			case 1:
 				EnterOuterAlt(_localctx, 1);
 				{
-				State = 306;
+				State = 320;
 				Match(GT);
 				}
 				break;
 			case 2:
 				EnterOuterAlt(_localctx, 2);
 				{
-				State = 307;
+				State = 321;
 				Match(GE);
 				}
 				break;
 			case 3:
 				EnterOuterAlt(_localctx, 3);
 				{
-				State = 308;
+				State = 322;
 				Match(LT);
 				}
 				break;
 			case 4:
 				EnterOuterAlt(_localctx, 4);
 				{
-				State = 309;
+				State = 323;
 				Match(LE);
 				}
 				break;
 			case 5:
 				EnterOuterAlt(_localctx, 5);
 				{
-				State = 310;
+				State = 324;
 				Match(EQ);
 				}
 				break;
 			case 6:
 				EnterOuterAlt(_localctx, 6);
 				{
-				State = 311;
+				State = 325;
 				Match(NE);
 				}
 				break;
 			case 7:
 				EnterOuterAlt(_localctx, 7);
 				{
-				State = 312;
+				State = 326;
 				Match(ISKEYWORD);
 				}
 				break;
 			case 8:
 				EnterOuterAlt(_localctx, 8);
 				{
-				State = 313;
+				State = 327;
 				Match(ISKEYWORD);
-				State = 314;
+				State = 328;
 				Match(NOTKEYWORD);
 				}
 				break;
@@ -2461,38 +2523,30 @@ public partial class ArcscriptParser : ArcscriptParserBase {
 		ExpressionContext _localctx = new ExpressionContext(Context, State);
 		EnterRule(_localctx, 74, RULE_expression);
 		try {
-			State = 320;
+			State = 334;
 			ErrorHandler.Sync(this);
-			switch (TokenStream.LA(1)) {
-			case STRING:
+			switch ( Interpreter.AdaptivePredict(TokenStream,30,Context) ) {
+			case 1:
 				EnterOuterAlt(_localctx, 1);
 				{
-				State = 317;
+				State = 331;
 				Match(STRING);
 				}
 				break;
-			case BOOLEAN:
+			case 2:
 				EnterOuterAlt(_localctx, 2);
 				{
-				State = 318;
+				State = 332;
 				Match(BOOLEAN);
 				}
 				break;
-			case FLOAT:
-			case INTEGER:
-			case LPAREN:
-			case ADD:
-			case SUB:
-			case FNAME:
-			case VARIABLE:
+			case 3:
 				EnterOuterAlt(_localctx, 3);
 				{
-				State = 319;
-				additive_numeric_expression();
+				State = 333;
+				additive_numeric_expression(0);
 				}
 				break;
-			default:
-				throw new NoViableAltException(this);
 			}
 		}
 		catch (RecognitionException re) {
@@ -2509,18 +2563,33 @@ public partial class ArcscriptParser : ArcscriptParserBase {
 	public override bool Sempred(RuleContext _localctx, int ruleIndex, int predIndex) {
 		switch (ruleIndex) {
 		case 21: return mention_sempred((MentionContext)_localctx, predIndex);
+		case 23: return additive_numeric_expression_sempred((Additive_numeric_expressionContext)_localctx, predIndex);
+		case 24: return multiplicative_numeric_expression_sempred((Multiplicative_numeric_expressionContext)_localctx, predIndex);
 		}
 		return true;
 	}
 	private bool mention_sempred(MentionContext _localctx, int predIndex) {
 		switch (predIndex) {
-		case 0: return this.assertMention(_localctx._attr);
+		case 0: return this.assertMention(_localctx._attr)
+				;
+		}
+		return true;
+	}
+	private bool additive_numeric_expression_sempred(Additive_numeric_expressionContext _localctx, int predIndex) {
+		switch (predIndex) {
+		case 1: return Precpred(Context, 1);
+		}
+		return true;
+	}
+	private bool multiplicative_numeric_expression_sempred(Multiplicative_numeric_expressionContext _localctx, int predIndex) {
+		switch (predIndex) {
+		case 2: return Precpred(Context, 1);
 		}
 		return true;
 	}
 
 	private static int[] _serializedATN = {
-		4,1,61,323,2,0,7,0,2,1,7,1,2,2,7,2,2,3,7,3,2,4,7,4,2,5,7,5,2,6,7,6,2,7,
+		4,1,61,337,2,0,7,0,2,1,7,1,2,2,7,2,2,3,7,3,2,4,7,4,2,5,7,5,2,6,7,6,2,7,
 		7,7,2,8,7,8,2,9,7,9,2,10,7,10,2,11,7,11,2,12,7,12,2,13,7,13,2,14,7,14,
 		2,15,7,15,2,16,7,16,2,17,7,17,2,18,7,18,2,19,7,19,2,20,7,20,2,21,7,21,
 		2,22,7,22,2,23,7,23,2,24,7,24,2,25,7,25,2,26,7,26,2,27,7,27,2,28,7,28,
@@ -2536,94 +2605,99 @@ public partial class ArcscriptParser : ArcscriptParserBase {
 		1,18,1,19,1,19,1,19,5,19,191,8,19,10,19,12,19,194,9,19,1,20,1,20,1,20,
 		3,20,199,8,20,1,21,1,21,5,21,203,8,21,10,21,12,21,206,9,21,1,21,1,21,3,
 		21,210,8,21,1,21,1,21,1,21,1,21,1,22,1,22,1,22,3,22,219,8,22,1,23,1,23,
-		1,23,3,23,224,8,23,1,24,1,24,1,24,3,24,229,8,24,1,25,1,25,1,25,1,25,3,
-		25,235,8,25,1,26,1,26,1,26,1,26,1,26,1,26,1,26,1,26,1,26,3,26,246,8,26,
-		1,27,1,27,1,27,3,27,251,8,27,1,27,1,27,1,27,1,28,1,28,1,28,3,28,259,8,
-		28,1,28,1,28,1,28,1,28,1,28,3,28,266,8,28,1,28,1,28,3,28,270,8,28,1,29,
-		1,29,1,30,1,30,1,30,5,30,277,8,30,10,30,12,30,280,9,30,1,30,1,30,1,31,
-		1,31,1,31,3,31,287,8,31,1,32,1,32,1,32,3,32,292,8,32,1,33,3,33,295,8,33,
-		1,33,1,33,1,34,1,34,1,35,1,35,1,35,1,35,3,35,305,8,35,1,36,1,36,1,36,1,
-		36,1,36,1,36,1,36,1,36,1,36,3,36,316,8,36,1,37,1,37,1,37,3,37,321,8,37,
-		1,37,2,94,99,0,38,0,2,4,6,8,10,12,14,16,18,20,22,24,26,28,30,32,34,36,
-		38,40,42,44,46,48,50,52,54,56,58,60,62,64,66,68,70,72,74,0,6,2,0,17,20,
-		33,33,1,0,23,24,1,0,21,22,2,0,32,32,47,47,2,0,31,31,46,46,2,0,34,34,49,
-		49,330,0,84,1,0,0,0,2,87,1,0,0,0,4,104,1,0,0,0,6,106,1,0,0,0,8,117,1,0,
-		0,0,10,125,1,0,0,0,12,131,1,0,0,0,14,133,1,0,0,0,16,135,1,0,0,0,18,139,
-		1,0,0,0,20,143,1,0,0,0,22,155,1,0,0,0,24,160,1,0,0,0,26,165,1,0,0,0,28,
-		170,1,0,0,0,30,173,1,0,0,0,32,176,1,0,0,0,34,180,1,0,0,0,36,185,1,0,0,
-		0,38,187,1,0,0,0,40,198,1,0,0,0,42,200,1,0,0,0,44,215,1,0,0,0,46,220,1,
-		0,0,0,48,225,1,0,0,0,50,234,1,0,0,0,52,245,1,0,0,0,54,247,1,0,0,0,56,269,
-		1,0,0,0,58,271,1,0,0,0,60,273,1,0,0,0,62,283,1,0,0,0,64,288,1,0,0,0,66,
-		294,1,0,0,0,68,298,1,0,0,0,70,300,1,0,0,0,72,315,1,0,0,0,74,320,1,0,0,
-		0,76,77,3,2,1,0,77,78,5,0,0,1,78,85,1,0,0,0,79,80,3,12,6,0,80,81,3,62,
-		31,0,81,82,3,14,7,0,82,83,5,0,0,1,83,85,1,0,0,0,84,76,1,0,0,0,84,79,1,
-		0,0,0,85,1,1,0,0,0,86,88,3,4,2,0,87,86,1,0,0,0,88,89,1,0,0,0,89,87,1,0,
-		0,0,89,90,1,0,0,0,90,3,1,0,0,0,91,93,3,6,3,0,92,91,1,0,0,0,93,94,1,0,0,
-		0,94,95,1,0,0,0,94,92,1,0,0,0,95,105,1,0,0,0,96,98,3,8,4,0,97,96,1,0,0,
-		0,98,99,1,0,0,0,99,100,1,0,0,0,99,97,1,0,0,0,100,105,1,0,0,0,101,105,3,
-		16,8,0,102,105,3,18,9,0,103,105,3,20,10,0,104,92,1,0,0,0,104,97,1,0,0,
-		0,104,101,1,0,0,0,104,102,1,0,0,0,104,103,1,0,0,0,105,5,1,0,0,0,106,112,
-		5,3,0,0,107,111,3,8,4,0,108,111,3,16,8,0,109,111,3,18,9,0,110,107,1,0,
-		0,0,110,108,1,0,0,0,110,109,1,0,0,0,111,114,1,0,0,0,112,110,1,0,0,0,112,
-		113,1,0,0,0,113,115,1,0,0,0,114,112,1,0,0,0,115,116,5,8,0,0,116,7,1,0,
-		0,0,117,118,3,10,5,0,118,119,5,5,0,0,119,120,6,4,-1,0,120,9,1,0,0,0,121,
-		122,5,2,0,0,122,126,6,5,-1,0,123,124,5,7,0,0,124,126,6,5,-1,0,125,121,
-		1,0,0,0,125,123,1,0,0,0,126,11,1,0,0,0,127,128,5,1,0,0,128,132,6,6,-1,
-		0,129,130,5,6,0,0,130,132,6,6,-1,0,131,127,1,0,0,0,131,129,1,0,0,0,132,
-		13,1,0,0,0,133,134,5,10,0,0,134,15,1,0,0,0,135,136,3,12,6,0,136,137,3,
-		34,17,0,137,138,3,14,7,0,138,17,1,0,0,0,139,140,3,12,6,0,140,141,3,36,
-		18,0,141,142,3,14,7,0,142,19,1,0,0,0,143,147,3,22,11,0,144,146,3,24,12,
-		0,145,144,1,0,0,0,146,149,1,0,0,0,147,145,1,0,0,0,147,148,1,0,0,0,148,
-		151,1,0,0,0,149,147,1,0,0,0,150,152,3,26,13,0,151,150,1,0,0,0,151,152,
-		1,0,0,0,152,153,1,0,0,0,153,154,3,32,16,0,154,21,1,0,0,0,155,156,3,12,
-		6,0,156,157,3,28,14,0,157,158,3,14,7,0,158,159,3,2,1,0,159,23,1,0,0,0,
-		160,161,3,12,6,0,161,162,3,30,15,0,162,163,3,14,7,0,163,164,3,2,1,0,164,
-		25,1,0,0,0,165,166,3,12,6,0,166,167,5,43,0,0,167,168,3,14,7,0,168,169,
-		3,2,1,0,169,27,1,0,0,0,170,171,5,42,0,0,171,172,3,62,31,0,172,29,1,0,0,
-		0,173,174,5,44,0,0,174,175,3,62,31,0,175,31,1,0,0,0,176,177,3,12,6,0,177,
-		178,5,45,0,0,178,179,3,14,7,0,179,33,1,0,0,0,180,181,5,51,0,0,181,182,
-		7,0,0,0,182,183,3,62,31,0,183,184,6,17,-1,0,184,35,1,0,0,0,185,186,3,56,
-		28,0,186,37,1,0,0,0,187,192,3,40,20,0,188,189,5,35,0,0,189,191,3,40,20,
-		0,190,188,1,0,0,0,191,194,1,0,0,0,192,190,1,0,0,0,192,193,1,0,0,0,193,
-		39,1,0,0,0,194,192,1,0,0,0,195,199,3,46,23,0,196,199,5,50,0,0,197,199,
-		3,42,21,0,198,195,1,0,0,0,198,196,1,0,0,0,198,197,1,0,0,0,199,41,1,0,0,
-		0,200,204,5,11,0,0,201,203,3,44,22,0,202,201,1,0,0,0,203,206,1,0,0,0,204,
-		202,1,0,0,0,204,205,1,0,0,0,205,207,1,0,0,0,206,204,1,0,0,0,207,209,5,
-		53,0,0,208,210,5,59,0,0,209,208,1,0,0,0,209,210,1,0,0,0,210,211,1,0,0,
-		0,211,212,5,58,0,0,212,213,5,56,0,0,213,214,4,21,0,1,214,43,1,0,0,0,215,
-		218,5,54,0,0,216,217,5,55,0,0,217,219,5,60,0,0,218,216,1,0,0,0,218,219,
-		1,0,0,0,219,45,1,0,0,0,220,223,3,48,24,0,221,222,7,1,0,0,222,224,3,46,
-		23,0,223,221,1,0,0,0,223,224,1,0,0,0,224,47,1,0,0,0,225,228,3,50,25,0,
-		226,227,7,2,0,0,227,229,3,48,24,0,228,226,1,0,0,0,228,229,1,0,0,0,229,
-		49,1,0,0,0,230,231,3,58,29,0,231,232,3,52,26,0,232,235,1,0,0,0,233,235,
-		3,52,26,0,234,230,1,0,0,0,234,233,1,0,0,0,235,51,1,0,0,0,236,246,5,12,
-		0,0,237,238,5,51,0,0,238,246,6,26,-1,0,239,246,5,13,0,0,240,246,3,54,27,
-		0,241,242,5,15,0,0,242,243,3,62,31,0,243,244,5,16,0,0,244,246,1,0,0,0,
-		245,236,1,0,0,0,245,237,1,0,0,0,245,239,1,0,0,0,245,240,1,0,0,0,245,241,
-		1,0,0,0,246,53,1,0,0,0,247,248,5,39,0,0,248,250,5,15,0,0,249,251,3,38,
-		19,0,250,249,1,0,0,0,250,251,1,0,0,0,251,252,1,0,0,0,252,253,5,16,0,0,
-		253,254,6,27,-1,0,254,55,1,0,0,0,255,256,5,40,0,0,256,258,5,15,0,0,257,
-		259,3,38,19,0,258,257,1,0,0,0,258,259,1,0,0,0,259,260,1,0,0,0,260,261,
-		5,16,0,0,261,270,6,28,-1,0,262,263,5,41,0,0,263,265,5,15,0,0,264,266,3,
-		60,30,0,265,264,1,0,0,0,265,266,1,0,0,0,266,267,1,0,0,0,267,268,5,16,0,
-		0,268,270,6,28,-1,0,269,255,1,0,0,0,269,262,1,0,0,0,270,57,1,0,0,0,271,
-		272,7,1,0,0,272,59,1,0,0,0,273,278,5,51,0,0,274,275,5,35,0,0,275,277,5,
-		51,0,0,276,274,1,0,0,0,277,280,1,0,0,0,278,276,1,0,0,0,278,279,1,0,0,0,
-		279,281,1,0,0,0,280,278,1,0,0,0,281,282,6,30,-1,0,282,61,1,0,0,0,283,286,
-		3,64,32,0,284,285,7,3,0,0,285,287,3,62,31,0,286,284,1,0,0,0,286,287,1,
-		0,0,0,287,63,1,0,0,0,288,291,3,66,33,0,289,290,7,4,0,0,290,292,3,64,32,
-		0,291,289,1,0,0,0,291,292,1,0,0,0,292,65,1,0,0,0,293,295,7,5,0,0,294,293,
-		1,0,0,0,294,295,1,0,0,0,295,296,1,0,0,0,296,297,3,68,34,0,297,67,1,0,0,
-		0,298,299,3,70,35,0,299,69,1,0,0,0,300,304,3,74,37,0,301,302,3,72,36,0,
-		302,303,3,74,37,0,303,305,1,0,0,0,304,301,1,0,0,0,304,305,1,0,0,0,305,
-		71,1,0,0,0,306,316,5,26,0,0,307,316,5,25,0,0,308,316,5,28,0,0,309,316,
-		5,27,0,0,310,316,5,29,0,0,311,316,5,30,0,0,312,316,5,48,0,0,313,314,5,
-		48,0,0,314,316,5,49,0,0,315,306,1,0,0,0,315,307,1,0,0,0,315,308,1,0,0,
-		0,315,309,1,0,0,0,315,310,1,0,0,0,315,311,1,0,0,0,315,312,1,0,0,0,315,
-		313,1,0,0,0,316,73,1,0,0,0,317,321,5,50,0,0,318,321,5,38,0,0,319,321,3,
-		46,23,0,320,317,1,0,0,0,320,318,1,0,0,0,320,319,1,0,0,0,321,75,1,0,0,0,
-		31,84,89,94,99,104,110,112,125,131,147,151,192,198,204,209,218,223,228,
-		234,245,250,258,265,269,278,286,291,294,304,315,320
+		1,23,1,23,1,23,1,23,5,23,227,8,23,10,23,12,23,230,9,23,1,24,1,24,1,24,
+		1,24,1,24,1,24,5,24,238,8,24,10,24,12,24,241,9,24,1,25,1,25,1,25,1,25,
+		3,25,247,8,25,1,26,1,26,1,26,1,26,1,26,1,26,1,26,1,26,1,26,1,26,1,26,3,
+		26,260,8,26,1,27,1,27,1,27,3,27,265,8,27,1,27,1,27,1,27,1,28,1,28,1,28,
+		3,28,273,8,28,1,28,1,28,1,28,1,28,1,28,3,28,280,8,28,1,28,1,28,3,28,284,
+		8,28,1,29,1,29,1,30,1,30,1,30,5,30,291,8,30,10,30,12,30,294,9,30,1,30,
+		1,30,1,31,1,31,1,31,3,31,301,8,31,1,32,1,32,1,32,3,32,306,8,32,1,33,3,
+		33,309,8,33,1,33,1,33,1,34,1,34,1,35,1,35,1,35,1,35,3,35,319,8,35,1,36,
+		1,36,1,36,1,36,1,36,1,36,1,36,1,36,1,36,3,36,330,8,36,1,37,1,37,1,37,3,
+		37,335,8,37,1,37,2,94,99,2,46,48,38,0,2,4,6,8,10,12,14,16,18,20,22,24,
+		26,28,30,32,34,36,38,40,42,44,46,48,50,52,54,56,58,60,62,64,66,68,70,72,
+		74,0,6,2,0,17,20,33,33,1,0,23,24,1,0,21,22,2,0,32,32,47,47,2,0,31,31,46,
+		46,2,0,34,34,49,49,346,0,84,1,0,0,0,2,87,1,0,0,0,4,104,1,0,0,0,6,106,1,
+		0,0,0,8,117,1,0,0,0,10,125,1,0,0,0,12,131,1,0,0,0,14,133,1,0,0,0,16,135,
+		1,0,0,0,18,139,1,0,0,0,20,143,1,0,0,0,22,155,1,0,0,0,24,160,1,0,0,0,26,
+		165,1,0,0,0,28,170,1,0,0,0,30,173,1,0,0,0,32,176,1,0,0,0,34,180,1,0,0,
+		0,36,185,1,0,0,0,38,187,1,0,0,0,40,198,1,0,0,0,42,200,1,0,0,0,44,215,1,
+		0,0,0,46,220,1,0,0,0,48,231,1,0,0,0,50,246,1,0,0,0,52,259,1,0,0,0,54,261,
+		1,0,0,0,56,283,1,0,0,0,58,285,1,0,0,0,60,287,1,0,0,0,62,297,1,0,0,0,64,
+		302,1,0,0,0,66,308,1,0,0,0,68,312,1,0,0,0,70,314,1,0,0,0,72,329,1,0,0,
+		0,74,334,1,0,0,0,76,77,3,2,1,0,77,78,5,0,0,1,78,85,1,0,0,0,79,80,3,12,
+		6,0,80,81,3,62,31,0,81,82,3,14,7,0,82,83,5,0,0,1,83,85,1,0,0,0,84,76,1,
+		0,0,0,84,79,1,0,0,0,85,1,1,0,0,0,86,88,3,4,2,0,87,86,1,0,0,0,88,89,1,0,
+		0,0,89,87,1,0,0,0,89,90,1,0,0,0,90,3,1,0,0,0,91,93,3,6,3,0,92,91,1,0,0,
+		0,93,94,1,0,0,0,94,95,1,0,0,0,94,92,1,0,0,0,95,105,1,0,0,0,96,98,3,8,4,
+		0,97,96,1,0,0,0,98,99,1,0,0,0,99,100,1,0,0,0,99,97,1,0,0,0,100,105,1,0,
+		0,0,101,105,3,16,8,0,102,105,3,18,9,0,103,105,3,20,10,0,104,92,1,0,0,0,
+		104,97,1,0,0,0,104,101,1,0,0,0,104,102,1,0,0,0,104,103,1,0,0,0,105,5,1,
+		0,0,0,106,112,5,3,0,0,107,111,3,8,4,0,108,111,3,16,8,0,109,111,3,18,9,
+		0,110,107,1,0,0,0,110,108,1,0,0,0,110,109,1,0,0,0,111,114,1,0,0,0,112,
+		110,1,0,0,0,112,113,1,0,0,0,113,115,1,0,0,0,114,112,1,0,0,0,115,116,5,
+		8,0,0,116,7,1,0,0,0,117,118,3,10,5,0,118,119,5,5,0,0,119,120,6,4,-1,0,
+		120,9,1,0,0,0,121,122,5,2,0,0,122,126,6,5,-1,0,123,124,5,7,0,0,124,126,
+		6,5,-1,0,125,121,1,0,0,0,125,123,1,0,0,0,126,11,1,0,0,0,127,128,5,1,0,
+		0,128,132,6,6,-1,0,129,130,5,6,0,0,130,132,6,6,-1,0,131,127,1,0,0,0,131,
+		129,1,0,0,0,132,13,1,0,0,0,133,134,5,10,0,0,134,15,1,0,0,0,135,136,3,12,
+		6,0,136,137,3,34,17,0,137,138,3,14,7,0,138,17,1,0,0,0,139,140,3,12,6,0,
+		140,141,3,36,18,0,141,142,3,14,7,0,142,19,1,0,0,0,143,147,3,22,11,0,144,
+		146,3,24,12,0,145,144,1,0,0,0,146,149,1,0,0,0,147,145,1,0,0,0,147,148,
+		1,0,0,0,148,151,1,0,0,0,149,147,1,0,0,0,150,152,3,26,13,0,151,150,1,0,
+		0,0,151,152,1,0,0,0,152,153,1,0,0,0,153,154,3,32,16,0,154,21,1,0,0,0,155,
+		156,3,12,6,0,156,157,3,28,14,0,157,158,3,14,7,0,158,159,3,2,1,0,159,23,
+		1,0,0,0,160,161,3,12,6,0,161,162,3,30,15,0,162,163,3,14,7,0,163,164,3,
+		2,1,0,164,25,1,0,0,0,165,166,3,12,6,0,166,167,5,43,0,0,167,168,3,14,7,
+		0,168,169,3,2,1,0,169,27,1,0,0,0,170,171,5,42,0,0,171,172,3,62,31,0,172,
+		29,1,0,0,0,173,174,5,44,0,0,174,175,3,62,31,0,175,31,1,0,0,0,176,177,3,
+		12,6,0,177,178,5,45,0,0,178,179,3,14,7,0,179,33,1,0,0,0,180,181,5,51,0,
+		0,181,182,7,0,0,0,182,183,3,62,31,0,183,184,6,17,-1,0,184,35,1,0,0,0,185,
+		186,3,56,28,0,186,37,1,0,0,0,187,192,3,40,20,0,188,189,5,35,0,0,189,191,
+		3,40,20,0,190,188,1,0,0,0,191,194,1,0,0,0,192,190,1,0,0,0,192,193,1,0,
+		0,0,193,39,1,0,0,0,194,192,1,0,0,0,195,199,3,46,23,0,196,199,5,50,0,0,
+		197,199,3,42,21,0,198,195,1,0,0,0,198,196,1,0,0,0,198,197,1,0,0,0,199,
+		41,1,0,0,0,200,204,5,11,0,0,201,203,3,44,22,0,202,201,1,0,0,0,203,206,
+		1,0,0,0,204,202,1,0,0,0,204,205,1,0,0,0,205,207,1,0,0,0,206,204,1,0,0,
+		0,207,209,5,53,0,0,208,210,5,59,0,0,209,208,1,0,0,0,209,210,1,0,0,0,210,
+		211,1,0,0,0,211,212,5,58,0,0,212,213,5,56,0,0,213,214,4,21,0,1,214,43,
+		1,0,0,0,215,218,5,54,0,0,216,217,5,55,0,0,217,219,5,60,0,0,218,216,1,0,
+		0,0,218,219,1,0,0,0,219,45,1,0,0,0,220,221,6,23,-1,0,221,222,3,48,24,0,
+		222,228,1,0,0,0,223,224,10,1,0,0,224,225,7,1,0,0,225,227,3,48,24,0,226,
+		223,1,0,0,0,227,230,1,0,0,0,228,226,1,0,0,0,228,229,1,0,0,0,229,47,1,0,
+		0,0,230,228,1,0,0,0,231,232,6,24,-1,0,232,233,3,50,25,0,233,239,1,0,0,
+		0,234,235,10,1,0,0,235,236,7,2,0,0,236,238,3,50,25,0,237,234,1,0,0,0,238,
+		241,1,0,0,0,239,237,1,0,0,0,239,240,1,0,0,0,240,49,1,0,0,0,241,239,1,0,
+		0,0,242,243,3,58,29,0,243,244,3,52,26,0,244,247,1,0,0,0,245,247,3,52,26,
+		0,246,242,1,0,0,0,246,245,1,0,0,0,247,51,1,0,0,0,248,260,5,12,0,0,249,
+		250,5,51,0,0,250,260,6,26,-1,0,251,260,5,13,0,0,252,260,5,50,0,0,253,260,
+		5,38,0,0,254,260,3,54,27,0,255,256,5,15,0,0,256,257,3,62,31,0,257,258,
+		5,16,0,0,258,260,1,0,0,0,259,248,1,0,0,0,259,249,1,0,0,0,259,251,1,0,0,
+		0,259,252,1,0,0,0,259,253,1,0,0,0,259,254,1,0,0,0,259,255,1,0,0,0,260,
+		53,1,0,0,0,261,262,5,39,0,0,262,264,5,15,0,0,263,265,3,38,19,0,264,263,
+		1,0,0,0,264,265,1,0,0,0,265,266,1,0,0,0,266,267,5,16,0,0,267,268,6,27,
+		-1,0,268,55,1,0,0,0,269,270,5,40,0,0,270,272,5,15,0,0,271,273,3,38,19,
+		0,272,271,1,0,0,0,272,273,1,0,0,0,273,274,1,0,0,0,274,275,5,16,0,0,275,
+		284,6,28,-1,0,276,277,5,41,0,0,277,279,5,15,0,0,278,280,3,60,30,0,279,
+		278,1,0,0,0,279,280,1,0,0,0,280,281,1,0,0,0,281,282,5,16,0,0,282,284,6,
+		28,-1,0,283,269,1,0,0,0,283,276,1,0,0,0,284,57,1,0,0,0,285,286,7,1,0,0,
+		286,59,1,0,0,0,287,292,5,51,0,0,288,289,5,35,0,0,289,291,5,51,0,0,290,
+		288,1,0,0,0,291,294,1,0,0,0,292,290,1,0,0,0,292,293,1,0,0,0,293,295,1,
+		0,0,0,294,292,1,0,0,0,295,296,6,30,-1,0,296,61,1,0,0,0,297,300,3,64,32,
+		0,298,299,7,3,0,0,299,301,3,62,31,0,300,298,1,0,0,0,300,301,1,0,0,0,301,
+		63,1,0,0,0,302,305,3,66,33,0,303,304,7,4,0,0,304,306,3,64,32,0,305,303,
+		1,0,0,0,305,306,1,0,0,0,306,65,1,0,0,0,307,309,7,5,0,0,308,307,1,0,0,0,
+		308,309,1,0,0,0,309,310,1,0,0,0,310,311,3,68,34,0,311,67,1,0,0,0,312,313,
+		3,70,35,0,313,69,1,0,0,0,314,318,3,74,37,0,315,316,3,72,36,0,316,317,3,
+		74,37,0,317,319,1,0,0,0,318,315,1,0,0,0,318,319,1,0,0,0,319,71,1,0,0,0,
+		320,330,5,26,0,0,321,330,5,25,0,0,322,330,5,28,0,0,323,330,5,27,0,0,324,
+		330,5,29,0,0,325,330,5,30,0,0,326,330,5,48,0,0,327,328,5,48,0,0,328,330,
+		5,49,0,0,329,320,1,0,0,0,329,321,1,0,0,0,329,322,1,0,0,0,329,323,1,0,0,
+		0,329,324,1,0,0,0,329,325,1,0,0,0,329,326,1,0,0,0,329,327,1,0,0,0,330,
+		73,1,0,0,0,331,335,5,50,0,0,332,335,5,38,0,0,333,335,3,46,23,0,334,331,
+		1,0,0,0,334,332,1,0,0,0,334,333,1,0,0,0,335,75,1,0,0,0,31,84,89,94,99,
+		104,110,112,125,131,147,151,192,198,204,209,218,228,239,246,259,264,272,
+		279,283,292,300,305,308,318,329,334
 	};
 
 	public static readonly ATN _ATN =


### PR DESCRIPTION
This PR adds string concatenation in the arcscript interpreter of the plugin and fixes an issue regarding the evaluation order of the math operations.