### PR TITLE
fix: option label rendering

### DIFF
--- a/Assets/Arcweave/Demo/ArcweavePlayerUI.cs
+++ b/Assets/Arcweave/Demo/ArcweavePlayerUI.cs
@@ -92,7 +92,7 @@ namespace Arcweave
         void OnElementOptions(Options options, System.Action<int> callback) {
             for ( var i = 0; i < options.Paths.Count; i++ ) {
                 var _i = i; //local var for the delegate
-                var text = !string.IsNullOrEmpty(options.Paths[i].label) ? options.Paths[i].label : "<i>[ N/A ]</i>";
+                var text = !string.IsNullOrEmpty(options.Paths[i].text) ? options.Paths[i].text : "<i>[ N/A ]</i>";
                 var button = MakeButton(text, () => callback(_i));
                 var pos = button.transform.position;
                 pos.y += buttonTemplate.GetComponent<RectTransform>().rect.height * ( options.Paths.Count - 1 - i );

--- a/Assets/Arcweave/Plugin/Runtime/Project/Element.cs
+++ b/Assets/Arcweave/Plugin/Runtime/Project/Element.cs
@@ -39,12 +39,6 @@ namespace Arcweave.Project
 
         void INode.InitializeInProject(Project project) { Project = project; }
         Path INode.ResolvePath(Path p) {
-            if (string.IsNullOrEmpty(p.label))
-            {
-                var i = new AwInterpreter(Project, Id);
-                var output = i.RunScript(Title);
-                p.label = Utils.CleanString(output.Output);
-            }
             p.TargetElement = this;
             return p;
         }

--- a/Assets/Arcweave/Plugin/Runtime/Project/HelperClasses.cs
+++ b/Assets/Arcweave/Plugin/Runtime/Project/HelperClasses.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using Arcweave.Interpreter;
 
 namespace Arcweave.Project
 {
@@ -41,6 +42,23 @@ namespace Arcweave.Project
     {
         ///<summary>The last label that lead to the target element</summary>
         public string label { get; set; }
+
+        public string text
+        {
+            get
+            {
+                if (!string.IsNullOrEmpty(label)) return label;
+                if (!string.IsNullOrEmpty(TargetElement.Title))
+                {
+                    var i = new AwInterpreter(TargetElement.Project, TargetElement.Id);
+                    var output = i.RunScript(TargetElement.Title);
+                    return Utils.CleanString(output.Output);
+                }
+
+                return null;
+            }
+        }
+
         ///<summary>The element that this path will lead/land to</summary>
         public Element TargetElement { get; set; }
         public List<Connection> _connections { get; set; }


### PR DESCRIPTION
This PR fixes an issue regarding option text rendering with the element title as fallback.

We are adding a `text` property in `Path` that returns the text to be rendered in the option button and we are using the label just for label connections.
Now:
- when `Element.ResolvePath` is called, the element is not setting the label of the Path.
- `Options.hasOptions` for a single option returns true only when the label is set from a connection.
- in `ArcweavePlayer.Next` if the current element has a single option without a label being set from a connection (and not from the element title), `onWaitInputNext` event is emitted.