### PR TITLE
feat: add api localization options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,3 +70,5 @@ crashlytics-build.properties
 # Temporary auto-generated Android Assets
 /[Aa]ssets/[Ss]treamingAssets/aa.meta
 /[Aa]ssets/[Ss]treamingAssets/aa/*
+
+.DS_Store

--- a/Assets/Arcweave/Plugin/Editor/ArcweaveProjectAssetInspector.cs
+++ b/Assets/Arcweave/Plugin/Editor/ArcweaveProjectAssetInspector.cs
@@ -1,5 +1,6 @@
 ﻿#if UNITY_EDITOR
 
+using System;
 using UnityEngine;
 using UnityEditor;
 
@@ -19,6 +20,27 @@ namespace Arcweave
             var fromWeb = aw.importSource == ArcweaveProjectAsset.ImportSource.FromWeb && !string.IsNullOrEmpty(aw.userAPIKey) && !string.IsNullOrEmpty(aw.projectHash);
             var text = "Import Project " + aw.importSource;
 
+            using (var group = new EditorGUILayout.FadeGroupScope(aw.importSource == ArcweaveProjectAsset.ImportSource.FromWeb ? 1f : 0f))
+            {
+                if (group.visible)
+                {
+                    aw.userAPIKey = EditorGUILayout.TextField(new GUIContent("User API Key", "Your Arcweave User API Key"), aw.userAPIKey);
+                    aw.projectHash = EditorGUILayout.TextField(new GUIContent("Project Hash", "The Arcweave Project Hash"), aw.projectHash);
+                    aw.locale = EditorGUILayout.TextField(new GUIContent("Language ISO", "The ISO of the language"), aw.locale);
+                    
+                    GUIContent content = new GUIContent("Fallback Content", "Enable to use fallback content when a string is not available in the specified language.");
+                    aw.fallbackLocales = EditorGUILayout.Toggle(content, aw.fallbackLocales);
+                }
+            }
+            
+            using (var group = new EditorGUILayout.FadeGroupScope(aw.importSource == ArcweaveProjectAsset.ImportSource.FromJson ? 1f : 0f))
+            {
+                if (group.visible)
+                {
+                    aw.projectJsonFile = (TextAsset)EditorGUILayout.ObjectField(new GUIContent("Project JSON File", "The Arcweave project JSON file"), aw.projectJsonFile, typeof(TextAsset), false);
+                }
+            }
+
             GUI.enabled = !isImporting && ( fromJson || fromWeb );
             if ( GUILayout.Button(text) ) {
                 isImporting = true;
@@ -27,6 +49,10 @@ namespace Arcweave
                     isImporting = false;
                     EditorUtility.SetDirty(aw);
                     AssetDatabase.SaveAssetIfDirty(aw);
+                },
+                (error) =>
+                {
+                    isImporting = false;
                 });
             }
             GUI.enabled = true;

--- a/Assets/Arcweave/Plugin/Editor/ProjectViewerWindow.cs
+++ b/Assets/Arcweave/Plugin/Editor/ProjectViewerWindow.cs
@@ -191,7 +191,7 @@ namespace Arcweave
             }
             GUILayout.FlexibleSpace();
             if ( GUILayout.Button("Re-Import", EditorStyles.toolbarButton) ) {
-                asset.ImportProject(null);
+                asset.ImportProject();
             }
             GUILayout.Space(SIDE_MARGIN);
             GUILayout.EndHorizontal();

--- a/Assets/Arcweave/Plugin/Runtime/ArcweaveProjectAsset.cs
+++ b/Assets/Arcweave/Plugin/Runtime/ArcweaveProjectAsset.cs
@@ -79,7 +79,6 @@ namespace Arcweave
                 }
             }
             var requestUrl = builder.ToString();
-            Debug.Log("Request URL: " + requestUrl);
             var request = UnityWebRequest.Get(requestUrl);
             request.SetRequestHeader("Authorization", string.Format("Bearer {0}", userAPIKey));
             request.SetRequestHeader("Accept", "application/json");

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Arcweave Plugin for Unity
 
-This plugin imports [Arcweave](https://arcweave.com/) projects into Unity. It supports data exported from **Arcweave Project > Export > Engine > Export for Unity** (available to all users) or fetched via Arcweave's web API (Team users only).
+This plugin imports [Arcweave](https://arcweave.com/) projects into Unity. It supports data exported from **Arcweave Project > Export > Engine > Export for Unity** (available to all users) or fetched via Arcweave's web API (available to Team workspaces only).
 
 ---
 
@@ -63,10 +63,10 @@ You will get a `.zip` file containing:
 
 ### Option 2: Use Arcweave's Web API
 
-Available to **Team account holders only**.
+Available to **Team workspaces**.
 
 You will need:
-- Your Team workspace **API key** (found in Workspace Settings).
+- Your Team workspace **API key** (found in your Workspace's API section).
 - Your **project hash** (found in Project Properties).
 
 See the [Arcweave API Documentation](https://docs.arcweave.com/integrations/web-api) for details.


### PR DESCRIPTION
This pull request enhances the Arcweave Unity plugin by improving the project import workflow, adding support for language-specific imports, and handling web request errors more robustly. The most important changes are grouped below:

**Editor UI Improvements:**

* Updated the inspector UI in `ArcweaveProjectAssetInspector.cs` to show relevant input fields based on the selected import source, including fields for API key, project hash, language ISO, and a toggle for fallback content. This makes it easier for users to configure imports from the web or JSON file.
* Improved error handling in the import button logic to reset the import state if an error occurs.

**Import Workflow Enhancements:**

* The `ImportProject` method in `ArcweaveProjectAsset.cs` now accepts an additional error callback, enabling better error reporting during project import.
* The `SendWebRequest` method builds request URLs with optional language (`locale`) and fallback content parameters, allowing for language-specific imports and more flexible content retrieval.
* Web request errors are now logged and passed to the error callback, improving feedback and debugging for failed imports.

**API and Data Model Updates:**

* Added new serialized fields to `ArcweaveProjectAsset` for `locale` and `fallbackLocales`, supporting multilingual and fallback content features. These fields are hidden in the inspector unless relevant.

**Minor Code Cleanup:**

* Updated using statements and improved type aliasing for clarity and debugging. [[1]](diffhunk://#diff-639ae3de771b1d9c258b924f5df6a1310e0af46abba7fdc8d158b0b673367d7fR3) [[2]](diffhunk://#diff-258553c2b11d02827ca90133e8e4190fde12d723fefc9b3da6aa5c11fa7879aaL1-R5)
* Simplified the re-import button logic in `ProjectViewerWindow.cs` to match the new `ImportProject` signature.