### PR TITLE
[Feature] - Import from web also in runtime

### DIFF
--- a/Assets/Arcweave/Demo/ArcweavePlayer.cs
+++ b/Assets/Arcweave/Demo/ArcweavePlayer.cs
@@ -37,6 +37,12 @@ namespace Arcweave
                 return;
             }
 
+            if (aw.Project == null || aw.Project.StartingElement == null)
+            {
+                Debug.LogWarning("The Arcweave Project Asset assigned in the inspector but has not been imported yet..importing it now");
+                aw.ImportProject(() => PlayProject(), (error) => Debug.LogError($"Failed to import Arcweave project: {error}"));
+                return;
+            }
             aw.Project.Initialize();
             if ( onProjectStart != null ) onProjectStart(aw.Project);
             Next(aw.Project.StartingElement);

--- a/Assets/Arcweave/Demo/ArcweavePlayer.cs
+++ b/Assets/Arcweave/Demo/ArcweavePlayer.cs
@@ -1,5 +1,5 @@
-﻿using UnityEngine;
-using Arcweave.Project;
+﻿using Arcweave.Project;
+using UnityEngine;
 
 namespace Arcweave
 {
@@ -28,11 +28,19 @@ namespace Arcweave
         public event OnElementOptions onElementOptions;
         public event OnWaitingInputNext onWaitInputNext;
 
-        void Start() { if ( autoStart ) PlayProject(); }
+        void Start()
+        {
+            if (autoStart)
+            {
+                PlayProject();
+            }
+        }
 
-        public void PlayProject() {
+        public void PlayProject()
+        {
 
-            if ( aw == null ) {
+            if (aw == null)
+            {
                 Debug.LogError("There is no Arcweave Project assigned in the inspector of Arcweave Player");
                 return;
             }
@@ -43,52 +51,65 @@ namespace Arcweave
                 aw.ImportProject(() => PlayProject(), (error) => Debug.LogError($"Failed to import Arcweave project: {error}"));
                 return;
             }
+
+
             aw.Project.Initialize();
-            if ( onProjectStart != null ) onProjectStart(aw.Project);
+            if (onProjectStart != null)
+            {
+                onProjectStart(aw.Project);
+            }
+
             Next(aw.Project.StartingElement);
         }
 
         /// Moves to the next element through a path
-        void Next(Path path) {
+        void Next(Path path)
+        {
             path.ExecuteAppendedConnectionLabels();
             Next(path.TargetElement);
         }
 
         /// Moves to the next element directly
-        void Next(Element element) {
+        void Next(Element element)
+        {
             currentElement = element;
             currentElement.Visits++;
-            if ( onElementEnter != null ) onElementEnter(element);
+            if (onElementEnter != null) onElementEnter(element);
             var currentState = currentElement.GetOptions();
-            if ( currentState.hasPaths ) {
-                if ( currentState.hasOptions ) {
-                    if ( onElementOptions != null ) {
+            if (currentState.hasPaths)
+            {
+                if (currentState.hasOptions)
+                {
+                    if (onElementOptions != null)
+                    {
                         onElementOptions(currentState, (index) => Next(currentState.Paths[index]));
                     }
                     return;
                 }
 
-                if ( onWaitInputNext != null ) onWaitInputNext(() => Next(currentState.Paths[0]));
+                if (onWaitInputNext != null) onWaitInputNext(() => Next(currentState.Paths[0]));
                 return;
             }
             currentElement = null;
-            if ( onProjectFinish != null ) onProjectFinish(aw.Project);
+            if (onProjectFinish != null) onProjectFinish(aw.Project);
         }
 
         ///----------------------------------------------------------------------------------------------
 
         /// Saves the current element and the variables
-        public void Save() {
+        public void Save()
+        {
             var id = currentElement.Id;
             var variables = aw.Project.SaveVariables();
-            PlayerPrefs.SetString(SAVE_KEY+"_currentElement", id);
-            PlayerPrefs.SetString(SAVE_KEY+"_variables", variables);
+            PlayerPrefs.SetString(SAVE_KEY + "_currentElement", id);
+            PlayerPrefs.SetString(SAVE_KEY + "_variables", variables);
         }
 
         /// Loads the previously saved element and the variables and moves to that element
-        public void Load() {
-            var id = PlayerPrefs.GetString(SAVE_KEY+"_currentElement");
-            var variables = PlayerPrefs.GetString(SAVE_KEY+"_variables");
+        public void Load()
+        {
+            var id = PlayerPrefs.GetString(SAVE_KEY + "_currentElement");
+            var variables = PlayerPrefs.GetString(SAVE_KEY + "_variables");
             var element = aw.Project.ElementWithId(id);
             aw.Project.LoadVariables(variables);
             Next(element);

--- a/Assets/Arcweave/Plugin/Runtime/ArcweaveProjectAsset.cs
+++ b/Assets/Arcweave/Plugin/Runtime/ArcweaveProjectAsset.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Diagnostics;
 using UnityEngine;
 using UnityEngine.Networking;
 using Debug = UnityEngine.Debug;
@@ -33,24 +32,31 @@ namespace Arcweave
         void ClearData() => Project = null;
 
         //...
-        protected void OnEnable() {
-            if ( Project != null ) {
+        protected void OnEnable()
+        {
+            if (Project != null)
+            {
                 Project.Initialize();
+                return;
             }
         }
 
         ///<summary>Import project from json text file or web and get callback when finished.</summary>
-        public void ImportProject(System.Action callback = null, System.Action<string> onError = null) {
-            if ( importSource == ImportSource.FromJson && projectJsonFile != null ) {
+        public void ImportProject(System.Action callback = null, System.Action<string> onError = null)
+        {
+            if (importSource == ImportSource.FromJson && projectJsonFile != null)
+            {
                 MakeProject(projectJsonFile.text, callback);
             }
-            if ( importSource == ImportSource.FromWeb && !string.IsNullOrEmpty(userAPIKey) ) {
+            if (importSource == ImportSource.FromWeb && !string.IsNullOrEmpty(userAPIKey) && !string.IsNullOrEmpty(projectHash))
+            {
                 SendWebRequest((j) => MakeProject(j, callback), onError);
             }
         }
 
         //...
-        async void MakeProject(string json, System.Action callback) {
+        async void MakeProject(string json, System.Action callback)
+        {
             Project.ProjectMaker maker = null;
             await System.Threading.Tasks.Task.Run(() =>
             {
@@ -61,11 +67,12 @@ namespace Arcweave
             });
 
             Debug.Log("Done");
-            if ( callback != null ) { callback(); }
+            if (callback != null) { callback(); }
         }
 
         //...
-        void SendWebRequest(System.Action<string> callbackSuccess, System.Action<string> callbackError) {
+        void SendWebRequest(System.Action<string> callbackSuccess, System.Action<string> callbackError)
+        {
             Debug.Log("Sending Web Request...");
 
             UriBuilder builder = new UriBuilder("https://arcweave.com/api/");
@@ -88,9 +95,12 @@ namespace Arcweave
                 var responseCode = request.responseCode;
                 Debug.Log(string.Format("Web Request Completed (code = {0})...", responseCode));
                 var result = request.downloadHandler?.text;
-                if ( responseCode == 200 && callbackSuccess != null ) {
+                if (responseCode == 200 && callbackSuccess != null)
+                {
                     callbackSuccess(result);
-                } else {
+                }
+                else
+                {
                     Debug.LogError(string.Format("Web Request Failed (code = {0}): {1}", responseCode, request.error));
                     if (callbackError != null)
                     {

--- a/Assets/Arcweave/Plugin/Runtime/Project/Project.cs
+++ b/Assets/Arcweave/Plugin/Runtime/Project/Project.cs
@@ -1,7 +1,6 @@
+using Arcweave.Interpreter.INodes;
 using System.Collections.Generic;
 using System.Linq;
-using Arcweave.Interpreter.INodes;
-using UnityEngine;
 using UnityEngine.Serialization;
 
 namespace Arcweave.Project
@@ -23,12 +22,14 @@ namespace Arcweave.Project
         [UnityEngine.SerializeField] private string _startingElementId;
         [System.NonSerialized] private Element _startingElement;
 
-        public Element StartingElement {
+        public Element StartingElement
+        {
             get { return _startingElement != null ? _startingElement : _startingElement = GetNodeWithID<Element>(_startingElementId); }
             set { _startingElementId = value.Id; _startingElement = value; }
         }
 
-        public Project(string name, Element startingElement, List<Board> boards, List<Component> components, List<Variable> variables) {
+        public Project(string name, Element startingElement, List<Board> boards, List<Component> components, List<Variable> variables)
+        {
             this.name = name;
             this.StartingElement = startingElement;
             this.Boards = boards;
@@ -39,11 +40,15 @@ namespace Arcweave.Project
         ///----------------------------------------------------------------------------------------------
 
         ///<summary>Should be called once before using the project.</summary>
-        public void Initialize() {
+        public void Initialize()
+        {
             ResetVariablesToDefaultValues();
             ResetVisits();
-            foreach ( var board in Boards ) {
-                foreach ( var node in board.Nodes ) {
+
+            foreach (var board in Boards)
+            {
+                foreach (var node in board.Nodes)
+                {
                     node.InitializeInProject(this);
                 }
             }
@@ -60,9 +65,12 @@ namespace Arcweave.Project
         public int Visits(string id) { return ElementWithId(id).Visits; }
 
         ///<summary>Reset the number of visits to 0 for all elements.</summary>
-        public void ResetVisits() {
-            foreach ( var board in Boards ) {
-                foreach ( var element in board.Nodes.OfType<Element>() ) {
+        public void ResetVisits()
+        {
+            foreach (var board in Boards)
+            {
+                foreach (var element in board.Nodes.OfType<Element>())
+                {
                     element.Visits = 0;
                 }
             }
@@ -78,11 +86,13 @@ namespace Arcweave.Project
         public Element ElementWithId(string id) => GetNodeWithID<Element>(id);
 
         ///<summary>Returns the INode of type T with id.</summary>
-        public T GetNodeWithID<T>(string id) where T : INode {
+        public T GetNodeWithID<T>(string id) where T : INode
+        {
             T result = default(T);
-            foreach ( var board in Boards ) {
+            foreach (var board in Boards)
+            {
                 result = board.NodeWithID<T>(id);
-                if ( result != null ) { return result; }
+                if (result != null) { return result; }
             }
             return result;
         }
@@ -93,9 +103,10 @@ namespace Arcweave.Project
         public Variable GetVariable(string name) => Variables.First(x => x.Name == name);
 
         ///<summary>Sets the variable with name to a new value. Returns if variable exists in the first place.</summary>
-        public bool SetVariable(string name, object value) {
+        public bool SetVariable(string name, object value)
+        {
             var variable = Variables.First(x => x.Name == name);
-            if ( variable == null ) { return false; }
+            if (variable == null) { return false; }
             variable.Value = value;
             return true;
         }
@@ -128,9 +139,9 @@ namespace Arcweave.Project
                 var type = System.Type.GetType(variableState.type);
                 object value = null;
                 if (type == typeof(string)) { value = variableState.value; }
-                if ( type == typeof(int) ) { value = int.Parse(variableState.value); }
-                if ( type == typeof(float) ) { value = float.Parse(variableState.value); }
-                if ( type == typeof(bool) ) { value = bool.Parse(variableState.value); }
+                if (type == typeof(int)) { value = int.Parse(variableState.value); }
+                if (type == typeof(float)) { value = float.Parse(variableState.value); }
+                if (type == typeof(bool)) { value = bool.Parse(variableState.value); }
                 SetVariable(variableState.name, value);
             }
         }


### PR DESCRIPTION
# WHAT

**Project initialization and import enhancements:**

* Updated `ArcweavePlayer.PlayProject()` to check if the project asset is imported and valid before starting; if not, it triggers an import and retries, improving reliability when assets are not yet loaded.
* Improved `ArcweaveProjectAsset.ImportProject()` to check for both `userAPIKey` and `projectHash` when importing from the web, preventing incomplete web requests.


**Error handling and logging:**

* Enhanced error handling in web requests by providing more detailed logs and ensuring error callbacks are invoked when requests fail.
* Added warnings when attempting to play a project that has not been imported, guiding users to proper setup.

## WHY
The manual import step was prone to being forgotten. This change attempts a runtime import if the starting element exists, streamlining the development workflow and preventing stale data issues.

In short - now before playing you won't need or won't forget to press "import"
<img width="484" height="244" alt="immagine" src="https://github.com/user-attachments/assets/aa533f8c-2d82-45b3-b69f-6a87d5496732" />



