### PR TITLE
[Fix][Feature] Add new save system, fix related bugs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,9 +2,9 @@
 #
 # Get latest from https://github.com/github/gitignore/blob/main/Unity.gitignore
 #
-/[Aa]ssets/
-!/[Aa]ssets/Arcweave
-!/[Aa]ssets/Arcweave/**/*
+!/[Aa]ssets/
+/[Aa]ssets/*
+!/[Aa]ssets/Arcweave/
 /[Pp]ackages/
 /[Ll]ibrary/
 /[Tt]emp/

--- a/Assets/Arcweave/Demo/ArcweaveDemoScene.unity
+++ b/Assets/Arcweave/Demo/ArcweaveDemoScene.unity
@@ -13,7 +13,7 @@ OcclusionCullingSettings:
 --- !u!104 &2
 RenderSettings:
   m_ObjectHideFlags: 0
-  serializedVersion: 9
+  serializedVersion: 10
   m_Fog: 0
   m_FogColor: {r: 0.5, g: 0.5, b: 0.5, a: 1}
   m_FogMode: 3
@@ -38,13 +38,12 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 0.37311953, g: 0.38074014, b: 0.3587274, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
   m_ObjectHideFlags: 0
-  serializedVersion: 12
-  m_GIWorkflowMode: 1
+  serializedVersion: 13
+  m_BakeOnSceneLoad: 0
   m_GISettings:
     serializedVersion: 2
     m_BounceScale: 1
@@ -67,9 +66,6 @@ LightmapSettings:
     m_LightmapParameters: {fileID: 0}
     m_LightmapsBakeMode: 1
     m_TextureCompression: 1
-    m_FinalGather: 0
-    m_FinalGatherFiltering: 1
-    m_FinalGatherRayCount: 256
     m_ReflectionCompression: 2
     m_MixedBakeMode: 2
     m_BakeBackend: 1
@@ -201,6 +197,7 @@ GameObject:
   m_Component:
   - component: {fileID: 1007191237}
   - component: {fileID: 1007191236}
+  - component: {fileID: 1007191238}
   m_Layer: 0
   m_Name: ArcweavePlayer
   m_TagString: Untagged
@@ -220,8 +217,10 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: af65da9c3b191244bacdcd1bdad5e7fd, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  aw: {fileID: 11400000, guid: 6b2922dee52894344bce3d90986ea14f, type: 2}
+  aw: {fileID: 11400000, guid: d7c634a4e63dfe841b52d81c0d542191, type: 2}
   autoStart: 1
+  saveMode: 1
+  saveHandler: {fileID: 1007191238}
 --- !u!4 &1007191237
 Transform:
   m_ObjectHideFlags: 0
@@ -237,6 +236,19 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1007191238
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1007191235}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d6b3636bce945a84e96f7f6b15ba23d2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::ArcweaveSaveHandler
+  debug: 0
 --- !u!1001 &1290797491
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -245,6 +257,114 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 0}
     m_Modifications:
+    - target: {fileID: 982859666, guid: e8f9dc58e4b2d4e4eb832a4bb5274656, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 982859666, guid: e8f9dc58e4b2d4e4eb832a4bb5274656, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 982859666, guid: e8f9dc58e4b2d4e4eb832a4bb5274656, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 982859666, guid: e8f9dc58e4b2d4e4eb832a4bb5274656, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1794690149, guid: e8f9dc58e4b2d4e4eb832a4bb5274656, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1794690149, guid: e8f9dc58e4b2d4e4eb832a4bb5274656, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1794690149, guid: e8f9dc58e4b2d4e4eb832a4bb5274656, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1794690149, guid: e8f9dc58e4b2d4e4eb832a4bb5274656, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1794690149, guid: e8f9dc58e4b2d4e4eb832a4bb5274656, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1814213445, guid: e8f9dc58e4b2d4e4eb832a4bb5274656, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1814213445, guid: e8f9dc58e4b2d4e4eb832a4bb5274656, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1814213445, guid: e8f9dc58e4b2d4e4eb832a4bb5274656, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1814213445, guid: e8f9dc58e4b2d4e4eb832a4bb5274656, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1814213445, guid: e8f9dc58e4b2d4e4eb832a4bb5274656, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1814213445, guid: e8f9dc58e4b2d4e4eb832a4bb5274656, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1096305320940284774, guid: e8f9dc58e4b2d4e4eb832a4bb5274656, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1096305320940284774, guid: e8f9dc58e4b2d4e4eb832a4bb5274656, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1096305320940284774, guid: e8f9dc58e4b2d4e4eb832a4bb5274656, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1096305320940284774, guid: e8f9dc58e4b2d4e4eb832a4bb5274656, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1096305320940284774, guid: e8f9dc58e4b2d4e4eb832a4bb5274656, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1096305320940284774, guid: e8f9dc58e4b2d4e4eb832a4bb5274656, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1283477759167917384, guid: e8f9dc58e4b2d4e4eb832a4bb5274656, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1283477759167917384, guid: e8f9dc58e4b2d4e4eb832a4bb5274656, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1283477759167917384, guid: e8f9dc58e4b2d4e4eb832a4bb5274656, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1283477759167917384, guid: e8f9dc58e4b2d4e4eb832a4bb5274656, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1283477759167917384, guid: e8f9dc58e4b2d4e4eb832a4bb5274656, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1283477759167917384, guid: e8f9dc58e4b2d4e4eb832a4bb5274656, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 1403719407132185570, guid: e8f9dc58e4b2d4e4eb832a4bb5274656, type: 3}
       propertyPath: m_Name
       value: '@ArcweavePlayerUI'
@@ -337,6 +457,174 @@ PrefabInstance:
       propertyPath: player
       value: 
       objectReference: {fileID: 1007191236}
+    - target: {fileID: 1403719407584412056, guid: e8f9dc58e4b2d4e4eb832a4bb5274656, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1403719407584412056, guid: e8f9dc58e4b2d4e4eb832a4bb5274656, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1403719407584412056, guid: e8f9dc58e4b2d4e4eb832a4bb5274656, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1403719407584412056, guid: e8f9dc58e4b2d4e4eb832a4bb5274656, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1403719407584412056, guid: e8f9dc58e4b2d4e4eb832a4bb5274656, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1403719407891140058, guid: e8f9dc58e4b2d4e4eb832a4bb5274656, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1403719407891140058, guid: e8f9dc58e4b2d4e4eb832a4bb5274656, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1403719407891140058, guid: e8f9dc58e4b2d4e4eb832a4bb5274656, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1403719408647371066, guid: e8f9dc58e4b2d4e4eb832a4bb5274656, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1403719408647371066, guid: e8f9dc58e4b2d4e4eb832a4bb5274656, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1403719408647371066, guid: e8f9dc58e4b2d4e4eb832a4bb5274656, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1403719408647371066, guid: e8f9dc58e4b2d4e4eb832a4bb5274656, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1403719408647371066, guid: e8f9dc58e4b2d4e4eb832a4bb5274656, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1403719408647371066, guid: e8f9dc58e4b2d4e4eb832a4bb5274656, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4172428831348126202, guid: e8f9dc58e4b2d4e4eb832a4bb5274656, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4172428831348126202, guid: e8f9dc58e4b2d4e4eb832a4bb5274656, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4172428831348126202, guid: e8f9dc58e4b2d4e4eb832a4bb5274656, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4172428831348126202, guid: e8f9dc58e4b2d4e4eb832a4bb5274656, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4172428831348126202, guid: e8f9dc58e4b2d4e4eb832a4bb5274656, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4172428831348126202, guid: e8f9dc58e4b2d4e4eb832a4bb5274656, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4293285047548803632, guid: e8f9dc58e4b2d4e4eb832a4bb5274656, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4293285047548803632, guid: e8f9dc58e4b2d4e4eb832a4bb5274656, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4293285047548803632, guid: e8f9dc58e4b2d4e4eb832a4bb5274656, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4293285047548803632, guid: e8f9dc58e4b2d4e4eb832a4bb5274656, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4887870288378345952, guid: e8f9dc58e4b2d4e4eb832a4bb5274656, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4887870288378345952, guid: e8f9dc58e4b2d4e4eb832a4bb5274656, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4887870288378345952, guid: e8f9dc58e4b2d4e4eb832a4bb5274656, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4887870288378345952, guid: e8f9dc58e4b2d4e4eb832a4bb5274656, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4887870288378345952, guid: e8f9dc58e4b2d4e4eb832a4bb5274656, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4887870288378345952, guid: e8f9dc58e4b2d4e4eb832a4bb5274656, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4973581039662420117, guid: e8f9dc58e4b2d4e4eb832a4bb5274656, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4973581039662420117, guid: e8f9dc58e4b2d4e4eb832a4bb5274656, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4973581039662420117, guid: e8f9dc58e4b2d4e4eb832a4bb5274656, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4973581039662420117, guid: e8f9dc58e4b2d4e4eb832a4bb5274656, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4973581039662420117, guid: e8f9dc58e4b2d4e4eb832a4bb5274656, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4973581039662420117, guid: e8f9dc58e4b2d4e4eb832a4bb5274656, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7497621245412270914, guid: e8f9dc58e4b2d4e4eb832a4bb5274656, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7497621245412270914, guid: e8f9dc58e4b2d4e4eb832a4bb5274656, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7497621245412270914, guid: e8f9dc58e4b2d4e4eb832a4bb5274656, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7497621245412270914, guid: e8f9dc58e4b2d4e4eb832a4bb5274656, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7497621245412270914, guid: e8f9dc58e4b2d4e4eb832a4bb5274656, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7497621245412270914, guid: e8f9dc58e4b2d4e4eb832a4bb5274656, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []

--- a/Assets/Arcweave/Demo/ArcweavePlayer.cs
+++ b/Assets/Arcweave/Demo/ArcweavePlayer.cs
@@ -1,91 +1,304 @@
-﻿using UnityEngine;
-using Arcweave.Project;
+﻿using Arcweave.Project;
+using UnityEngine;
 
 namespace Arcweave
 {
-    /// This is not required to utilize an Arcweave project but can be helpful for some projects as well as a learning example.
+    /// <summary>
+    /// Defines when the ArcweavePlayer should automatically save progress.
+    /// </summary>
+    public enum SaveMode
+    {
+        /// <summary>No automatic saving. Use RequestSave() manually to save progress.</summary>
+        Manual,
+        /// <summary>Automatically saves when the project reaches an end element (no more paths).</summary>
+        AutoSaveOnEnd
+    }
+
+    ///This is not required to utilize an arweave project but can be helpful for some projects as well as a learning example.
     public class ArcweavePlayer : MonoBehaviour
     {
-        // Delegates for the events
+        //Delegates for the events.
         public delegate void OnProjectStart(Project.Project project);
         public delegate void OnProjectFinish(Project.Project project);
         public delegate void OnElementEnter(Element element);
         public delegate void OnElementOptions(Options options, System.Action<int> next);
         public delegate void OnWaitingInputNext(System.Action next);
-
-        public const string SAVE_KEY = "arcweave_save";
+        public delegate void OnProjectUpdated(Project.Project project);
 
         public Arcweave.ArcweaveProjectAsset aw;
 
+        [Tooltip("If true, automatically starts playing the project when the scene loads.")]
         public bool autoStart = true;
 
-        private Element currentElement;
+        [Tooltip("Controls when the player automatically saves progress. Manual requires calling RequestSave() explicitly.")]
+        public SaveMode saveMode = SaveMode.AutoSaveOnEnd;
 
-        // Events that the UI (or otherwise) can subscribe to get notified and act accordingly
+        private Element currentElement;
+        private bool isInitialized = false;
+
+        //events that that UI (or otherwise) can subscribe to get notified and act accordingly.
         public event OnProjectStart onProjectStart;
         public event OnProjectFinish onProjectFinish;
         public event OnElementEnter onElementEnter;
         public event OnElementOptions onElementOptions;
         public event OnWaitingInputNext onWaitInputNext;
+        public event OnProjectUpdated onProjectUpdated;
 
-        void Start() { if ( autoStart ) PlayProject(); }
+        [SerializeField, Tooltip("Optional save handler component to handle save/load events. If not assigned, save/load events will be logged with a warning.")]
+        private ArcweaveSaveHandler saveHandler;
 
-        public void PlayProject() {
+        void Awake()
+        {
+            // Ensure we have a valid project asset
+            if (aw == null)
+            {
+                Debug.LogError("No Arcweave Project Asset assigned to ArcweavePlayer");
+            }
+        }
 
-            if ( aw == null ) {
+        void Start()
+        {
+            if (autoStart) PlayProject();
+        }
+
+        /// <summary>
+        /// Initialize the project if not already initialized
+        /// </summary>
+        public void EnsureInitialized()
+        {
+            Debug.Log("[ArcweavePlayer] EnsureInitialized() called");
+            if (isInitialized)
+            {
+                Debug.Log("[ArcweavePlayer] Already initialized, skipping");
+                return;
+            }
+
+            if (aw == null || aw.Project == null)
+            {
+                Debug.LogError("Cannot initialize Arcweave project - missing project asset");
+                return;
+            }
+
+            // Initialize the project
+            aw.Project.Initialize();
+
+            if(!RequestLoad())
+            {
+                Debug.LogWarning("[ArcweavePlayer] Load request failed - no saved data available");
+            }
+
+            isInitialized = true;
+
+            if (onProjectUpdated != null) onProjectUpdated(aw.Project);
+        }
+
+        /// <summary>
+        /// Play the Arcweave project from the beginning
+        /// </summary>
+        public void PlayProject()
+        {
+            if (aw == null)
+            {
                 Debug.LogError("There is no Arcweave Project assigned in the inspector of Arcweave Player");
                 return;
             }
 
-            aw.Project.Initialize();
-            if ( onProjectStart != null ) onProjectStart(aw.Project);
-            Next(aw.Project.StartingElement);
+            // Ensure project is initialized
+            EnsureInitialized();
+
+            Element startingElement = FindStartingElement();
+            if (startingElement == null)
+            {
+                Debug.LogError("No starting element found with the specified criteria");
+                return;
+            }
+
+            if (onProjectStart != null) onProjectStart(aw.Project);
+
+            Next(startingElement);
         }
 
+        /// <summary>
+        /// Find a suitable starting element for the project.
+        /// Returns the starting element configured in the Arcweave project.
+        /// Note: in the 3D demo, autoStart should be false — DialogueTrigger
+        /// drives dialogue per-NPC via EnsureInitialized() + Next(element) directly.
+        /// </summary>
+        private Element FindStartingElement()
+        {
+            return aw?.Project?.StartingElement;
+        }
+
+        /// <summary>
         /// Moves to the next element through a path
-        void Next(Path path) {
+        /// </summary>
+        void Next(Path path)
+        {
+            if (path == null)
+            {
+                Debug.LogError("Cannot navigate to null path");
+                return;
+            }
+
             path.ExecuteAppendedConnectionLabels();
             Next(path.TargetElement);
         }
 
-        /// Moves to the next element directly
-        void Next(Element element) {
+        /// <summary>
+        /// Moves to the next/an element directly
+        /// </summary>
+        public void Next(Element element)
+        {
+            if (element == null)
+            {
+                Debug.LogError("Cannot navigate to null element");
+                if (onProjectFinish != null) onProjectFinish(aw.Project);
+                return;
+            }
+
             currentElement = element;
             currentElement.Visits++;
-            if ( onElementEnter != null ) onElementEnter(element);
+
+            // Check if element has content
+            if (!currentElement.HasContent())
+            {
+                Debug.LogWarning($"Element '{currentElement.Title}' has no content");
+            }
+
+            if (onElementEnter != null) onElementEnter(element);
+
             var currentState = currentElement.GetOptions();
-            if ( currentState.hasPaths ) {
-                if ( currentState.hasOptions ) {
-                    if ( onElementOptions != null ) {
+            if (currentState.hasPaths)
+            {
+                if (currentState.hasOptions)
+                {
+                    if (onElementOptions != null)
+                    {
                         onElementOptions(currentState, (index) => Next(currentState.Paths[index]));
                     }
                     return;
                 }
 
-                if ( onWaitInputNext != null ) onWaitInputNext(() => Next(currentState.Paths[0]));
+                if (onWaitInputNext != null) onWaitInputNext(() => Next(currentState.Paths[0]));
+
                 return;
             }
+
+            // No paths means the project has reached an end.
+            if (saveMode == SaveMode.AutoSaveOnEnd)
+            {
+                RequestSave();
+            }
+
             currentElement = null;
-            if ( onProjectFinish != null ) onProjectFinish(aw.Project);
+            if (onProjectFinish != null) onProjectFinish(aw.Project);
         }
 
-        ///----------------------------------------------------------------------------------------------
+#region SAVES
+        /// <summary>
+        /// Requests a save of the current game state.
+        /// If a saveHandler is assigned, it will handle saving the current element ID and project variables.
+        /// This can be called manually at any time, or automatically based on the saveMode setting.
+        /// </summary>
+        public void RequestSave()
+        {
+            if (currentElement == null)
+            {
+                Debug.LogWarning("Cannot request save - no current element");
+                return;
+            }
 
-        /// Saves the current element and the variables
-        public void Save() {
             var id = currentElement.Id;
             var variables = aw.Project.SaveVariables();
-            PlayerPrefs.SetString(SAVE_KEY+"_currentElement", id);
-            PlayerPrefs.SetString(SAVE_KEY+"_variables", variables);
+            var visits = aw.Project.SaveVisits();
+
+            if (saveHandler != null)
+            {
+                saveHandler.HandleSaveRequest(id, variables, visits);
+            }
+            else
+            {
+                Debug.LogWarning("Save request was made but no handlers are set in the ArcweavePlayer");
+            }
         }
 
-        /// Loads the previously saved element and the variables and moves to that element
-        public void Load() {
-            var id = PlayerPrefs.GetString(SAVE_KEY+"_currentElement");
-            var variables = PlayerPrefs.GetString(SAVE_KEY+"_variables");
-            var element = aw.Project.ElementWithId(id);
-            aw.Project.LoadVariables(variables);
-            Next(element);
+        /// <summary>
+        /// Requests loading of a previously saved game state.
+        /// If a saveHandler is assigned, it will retrieve the saved element ID and variables,
+        /// restore the project state, and navigate to the saved element.
+        /// Call this method to resume a saved game session.
+        /// </summary>
+        /// <returns>True if the load was successful and navigation occurred; false otherwise.</returns>
+        public bool RequestLoad()
+        {
+            Debug.Log("[ArcweavePlayer] RequestLoad() called");
+            if (saveHandler == null)
+            {
+                Debug.LogWarning("Load request was made but no handlers are set in the ArcweavePlayer");
+                return false;
+            }
+
+            string elementId, variables, visits;
+            if (saveHandler.HandleLoadRequest(out elementId, out variables, out visits))
+            {
+                var element = aw.Project.ElementWithId(elementId);
+                if (element != null)
+                {
+                    Debug.Log($"[ArcweavePlayer] Loading variables before restoring state");
+                    aw.Project.LoadVariables(variables);
+                    aw.Project.LoadVisits(visits);
+                    Debug.Log($"[ArcweavePlayer] Variables loaded, navigating to element: {element.Title}");
+                    Next(element);
+                    return true;
+                }
+                Debug.LogError($"Cannot load - element with ID '{elementId}' not found");
+            }
+            else
+            {
+                Debug.Log("[ArcweavePlayer] Load request handler returned false - no saved data available");
+            }
+
+            return false;
         }
-    }
-}
+
+        /// <summary>
+        /// Resets all project variables to their default values and clears any saved state.
+        /// If a saveHandler is assigned, it will clear the saved data.
+        /// This is useful for starting a fresh playthrough.
+        /// </summary>
+        public void ResetVariables()
+        {
+            if (saveHandler != null)
+            {
+                saveHandler.ResetSave();
+            }
+
+            if (aw != null && aw.Project != null)
+            {
+                aw.Project.Initialize(); // This will reset all variables to their default values
+                isInitialized = true;
+            }
+        }
+
+        public bool HasSave()
+        {
+            if (saveHandler != null)
+            {
+                saveHandler.HasSave();
+            }
+
+            return false;
+        }
+#endregion
+
+        private void OnApplicationQuit()
+        {
+            if (saveMode == SaveMode.AutoSaveOnEnd)
+            {
+                RequestSave();
+            }
+        }
+
+    }// end class
+
+}// end namespace

--- a/Assets/Arcweave/Demo/ArcweavePlayer.cs
+++ b/Assets/Arcweave/Demo/ArcweavePlayer.cs
@@ -82,7 +82,7 @@ namespace Arcweave
             // Initialize the project
             aw.Project.Initialize();
 
-            if(!RequestLoad())
+            if (!RequestLoad())
             {
                 Debug.LogWarning("[ArcweavePlayer] Load request failed - no saved data available");
             }
@@ -248,7 +248,7 @@ namespace Arcweave
                     aw.Project.LoadVariables(variables);
                     aw.Project.LoadVisits(visits);
                     Debug.Log($"[ArcweavePlayer] Variables loaded, navigating to element: {element.Title}");
-                    Next(element);
+                    aw.Project.StartingElement = element; // Set the starting element to the loaded element
                     return true;
                 }
                 Debug.LogError($"Cannot load - element with ID '{elementId}' not found");

--- a/Assets/Arcweave/Demo/ArcweavePlayerUI.cs
+++ b/Assets/Arcweave/Demo/ArcweavePlayerUI.cs
@@ -51,7 +51,14 @@ namespace Arcweave
 
             saveButton.onClick.AddListener(Save);
             loadButton.onClick.AddListener(Load);
-            loadButton.gameObject.SetActive(PlayerPrefs.HasKey(ArcweavePlayer.SAVE_KEY));
+            
+            if(player == null)
+            {
+                gameObject.SetActive(false);
+                Debug.LogWarning("No ArcweavePlayer assigned to ArcweavePlayerUI. Disabling UI.");
+            }
+
+            loadButton.gameObject.SetActive(player.HasSave());
 
             player.onElementEnter += OnElementEnter;
             player.onElementOptions += OnElementOptions;
@@ -67,13 +74,32 @@ namespace Arcweave
         }
 
         void Save() {
-            player.Save();
+
+            if (player == null)
+            {
+                return;
+            }
+
+            player.RequestSave();
             loadButton.gameObject.SetActive(true);
         }
 
         void Load() {
-            ClearTempButtons();
-            player.Load();
+
+            if (player == null)
+            {
+                return;
+            }
+
+            if (player.RequestLoad())
+            {
+                ClearTempButtons();
+                Debug.Log("Arcweave state loaded");
+            }
+            else
+            {
+                Debug.LogWarning("No saved state found");
+            }
         }
 
         ///----------------------------------------------------------------------------------------------

--- a/Assets/Arcweave/Demo/Editor.meta
+++ b/Assets/Arcweave/Demo/Editor.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 519764ce7c9b8ea46b12a2e209d62d25
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Arcweave/Demo/Editor/ArcweavePlayerEditor.cs
+++ b/Assets/Arcweave/Demo/Editor/ArcweavePlayerEditor.cs
@@ -1,0 +1,68 @@
+#if UNITY_EDITOR
+
+using UnityEngine;
+using UnityEditor;
+
+namespace Arcweave
+{
+    [CustomEditor(typeof(ArcweavePlayer))]
+    public class ArcweavePlayerEditor : Editor
+    {
+        public override void OnInspectorGUI()
+        {
+            // Draw the default inspector
+            DrawDefaultInspector();
+
+            // Add some space before the button
+            EditorGUILayout.Space(10);
+
+            // Add a separator line
+            EditorGUILayout.LabelField("", GUI.skin.horizontalSlider);
+
+            // Add a header for the editor tools section
+            EditorGUILayout.LabelField("Editor Tools", EditorStyles.boldLabel);
+
+            ArcweavePlayer player = (ArcweavePlayer)target;
+
+            // Add the Reset Save button
+            GUI.enabled = Application.isPlaying || EditorApplication.isPlaying == false;
+
+            if (GUILayout.Button("Reset Save File", GUILayout.Height(30)))
+            {
+                if (EditorUtility.DisplayDialog(
+                    "Reset Save File",
+                    "This will delete all saved game data including the current element and all variable states. This action cannot be undone.\n\nAre you sure you want to proceed?",
+                    "Yes, Reset Save",
+                    "Cancel"))
+                {
+                    ResetSaveFile(player);
+                }
+            }
+
+            GUI.enabled = true;
+
+            // Add help box with information
+            EditorGUILayout.Space(5);
+            EditorGUILayout.HelpBox(
+                "Reset Save File: Clears all saved game data stored in PlayerPrefs. " +
+                "This includes the current element ID, all variable states and visit counts. " +
+                "Use this to start fresh or clear test data.",
+                MessageType.Info);
+        }
+
+        private void ResetSaveFile(ArcweavePlayer player)
+        {
+            // Call the ResetVariables method which handles the save handler
+            player.ResetVariables();
+
+            Debug.Log("Save file reset successfully. All saved game data has been cleared.");
+
+            EditorUtility.DisplayDialog(
+                "Save File Reset",
+                "Save file has been reset successfully.\n\nAll saved game data has been cleared from PlayerPrefs.",
+                "OK");
+        }
+    }
+}
+
+#endif

--- a/Assets/Arcweave/Demo/Editor/ArcweavePlayerEditor.cs.meta
+++ b/Assets/Arcweave/Demo/Editor/ArcweavePlayerEditor.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 439916fcb1c88514abbaa1d593b13225

--- a/Assets/Arcweave/Demo/Handlers.meta
+++ b/Assets/Arcweave/Demo/Handlers.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: e2f9c65e5c3a0ef4a82d554db4327778
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Arcweave/Demo/Handlers/ArcweaveSaveHandler.cs
+++ b/Assets/Arcweave/Demo/Handlers/ArcweaveSaveHandler.cs
@@ -1,0 +1,95 @@
+using Arcweave;
+using Arcweave.Project;
+using UnityEngine;
+
+public class ArcweaveSaveHandler : MonoBehaviour
+{
+    public const string SAVE_KEY = "arcweave_save";
+
+    [SerializeField, Tooltip("Activate to print debug logs for save handler")]
+    private bool debug = false;
+
+    public bool HandleSaveRequest(string elementId, string variables, string visits)
+    {
+        if(debug)
+        {
+            Debug.Log($"[ArcweaveSaveHandler] HandleSaveRequest() - ElementID: {elementId}");
+            Debug.Log($"[ArcweaveSaveHandler] Variables to save: {variables}");
+            Debug.Log($"[ArcweaveSaveHandler] Visits to save: {visits}");
+        }
+
+
+        PlayerPrefs.SetString(SAVE_KEY + "_currentElement", elementId);
+        PlayerPrefs.SetString(SAVE_KEY + "_variables", variables);
+        PlayerPrefs.SetString(SAVE_KEY + "_visits", visits);
+
+        PlayerPrefs.Save();
+        if (debug)
+        {
+            Debug.Log("[ArcweaveSaveHandler] Save completed successfully");
+        }
+
+        return true;
+    }
+
+    public bool HandleLoadRequest(out string elementId, out string variables, out string visits)
+    {
+        if (debug)
+        {
+            Debug.Log("[ArcweaveSaveHandler] HandleLoadRequest() called");
+        }
+
+        elementId = null;
+        variables = null;
+        visits = null;
+
+        if (!HasSave())
+        {
+            Debug.LogWarning("[ArcweaveSaveHandler] No saved state found");
+            return false;
+        }
+
+        elementId = PlayerPrefs.GetString(SAVE_KEY + "_currentElement");
+        variables = PlayerPrefs.GetString(SAVE_KEY + "_variables");
+        visits = PlayerPrefs.GetString(SAVE_KEY + "_visits");
+
+        if (debug)
+        {
+            Debug.Log($"[ArcweaveSaveHandler] Loaded - Element ID: {elementId}, Variables: {variables}");
+        }
+
+        if (string.IsNullOrEmpty(elementId) || string.IsNullOrEmpty(variables))
+        {
+            Debug.LogWarning("[ArcweaveSaveHandler] Saved state is invalid");
+            return false;
+        }
+
+        return true;
+    }
+
+    public void ResetSave()
+    {
+        PlayerPrefs.DeleteKey(SAVE_KEY + "_currentElement");
+        PlayerPrefs.DeleteKey(SAVE_KEY + "_variables");
+        PlayerPrefs.DeleteKey(SAVE_KEY + "_visits");
+        PlayerPrefs.Save();
+
+        if (debug)
+        {
+            Debug.Log("Save state reset");
+        }
+    }
+
+    public bool HasSave()
+    {
+         if (!PlayerPrefs.HasKey(SAVE_KEY + "_currentElement")
+            || !PlayerPrefs.HasKey(SAVE_KEY + "_variables")
+            || !PlayerPrefs.HasKey(SAVE_KEY + "_visits")
+           )
+        {
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/Assets/Arcweave/Demo/Handlers/ArcweaveSaveHandler.cs.meta
+++ b/Assets/Arcweave/Demo/Handlers/ArcweaveSaveHandler.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: d6b3636bce945a84e96f7f6b15ba23d2

--- a/Assets/Arcweave/Plugin/Runtime/Project/ArcweaveVisitsState.cs
+++ b/Assets/Arcweave/Plugin/Runtime/Project/ArcweaveVisitsState.cs
@@ -1,0 +1,61 @@
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+using static Arcweave.Project.State;
+
+
+namespace Arcweave.Project
+{
+    /* 
+     * Support class to keep a save of the element visits
+     */
+    internal class ArcweaveVisitsState
+    {
+        [Serializable]
+        internal struct VisitsState
+        {
+            public string elementId;
+            public int nVisit;
+        };
+
+        [SerializeField]
+        private VisitsState[] visits;
+
+        public ArcweaveVisitsState(Dictionary<string, int> visitDictionary)
+        {
+           SetVisitsState(visitDictionary);
+        }
+
+        public void SetVisitsState(Dictionary<string, int> elementVisits)
+        {
+            if (elementVisits != null && elementVisits.Count > 0)
+            {
+                visits = new VisitsState[elementVisits.Count];
+                int i = 0;
+                foreach (var kvp in elementVisits)
+                {
+                    visits[i].elementId = kvp.Key;
+                    visits[i].nVisit = kvp.Value;
+                    i++;
+                }
+            }
+        }
+
+        public string ToJson()
+        {
+            return JsonUtility.ToJson(this);
+        }
+
+        public static ArcweaveVisitsState FromJson(string json)
+        {
+            var state = JsonUtility.FromJson<ArcweaveVisitsState>(json);
+            return state;
+        }
+
+        public VisitsState[] GetVisits()
+        {
+            return visits;
+        }
+    }
+
+}

--- a/Assets/Arcweave/Plugin/Runtime/Project/ArcweaveVisitsState.cs
+++ b/Assets/Arcweave/Plugin/Runtime/Project/ArcweaveVisitsState.cs
@@ -1,14 +1,13 @@
 using System;
 using System.Collections.Generic;
 using UnityEngine;
-using static Arcweave.Project.State;
-
 
 namespace Arcweave.Project
 {
     /* 
      * Support class to keep a save of the element visits
      */
+    [Serializable]
     internal class ArcweaveVisitsState
     {
         [Serializable]
@@ -48,6 +47,12 @@ namespace Arcweave.Project
 
         public static ArcweaveVisitsState FromJson(string json)
         {
+            if (string.IsNullOrEmpty(json))
+            {
+                Debug.LogWarning("ArcweaveVisitsState.FromJson: Received null or empty JSON string. Returning an empty ArcweaveVisitsState.");
+                return new ArcweaveVisitsState(new Dictionary<string, int>());
+            }
+
             var state = JsonUtility.FromJson<ArcweaveVisitsState>(json);
             return state;
         }

--- a/Assets/Arcweave/Plugin/Runtime/Project/ArcweaveVisitsState.cs.meta
+++ b/Assets/Arcweave/Plugin/Runtime/Project/ArcweaveVisitsState.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 9b133688af0c9a84ab2b795ec7cecc8a

--- a/Assets/Arcweave/Plugin/Runtime/Project/AssetScripts.meta
+++ b/Assets/Arcweave/Plugin/Runtime/Project/AssetScripts.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 0eb67e4d47092674eabeb23a3b976ae5
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Arcweave/Plugin/Runtime/Project/Project.cs
+++ b/Assets/Arcweave/Plugin/Runtime/Project/Project.cs
@@ -1,7 +1,5 @@
 using Arcweave.Interpreter.INodes;
-using System;
 using System.Collections.Generic;
-using System.Collections.Specialized;
 using System.Linq;
 using UnityEngine;
 using UnityEngine.Serialization;

--- a/Assets/Arcweave/Plugin/Runtime/Project/Project.cs
+++ b/Assets/Arcweave/Plugin/Runtime/Project/Project.cs
@@ -1,6 +1,8 @@
-using System.Collections.Generic;
-using System.Linq;
 using Arcweave.Interpreter.INodes;
+using System;
+using System.Collections.Generic;
+using System.Collections.Specialized;
+using System.Linq;
 using UnityEngine;
 using UnityEngine.Serialization;
 
@@ -128,10 +130,59 @@ namespace Arcweave.Project
                 var type = System.Type.GetType(variableState.type);
                 object value = null;
                 if (type == typeof(string)) { value = variableState.value; }
-                if ( type == typeof(int) ) { value = int.Parse(variableState.value); }
-                if ( type == typeof(float) ) { value = float.Parse(variableState.value); }
-                if ( type == typeof(bool) ) { value = bool.Parse(variableState.value); }
+                else if ( type == typeof(int) ) { value = int.Parse(variableState.value); }
+                else if ( type == typeof(float) ) { value = float.Parse(variableState.value); }
+                else if ( type == typeof(bool) ) { value = bool.Parse(variableState.value); }
                 SetVariable(variableState.name, value);
+            }
+        }
+
+        internal string SaveVisits()
+        {
+            var visitDictionary = new Dictionary<string, int>();
+            foreach (var board in Boards)
+            {
+                foreach (var element in board.Nodes.OfType<Element>())
+                {
+                    if (element.Visits > 0)
+                    {
+                        visitDictionary[element.Id] = element.Visits;
+                        UnityEngine.Debug.Log($"[Project] Saving visit count for element '{element.Title}' (ID: {element.Id}): {element.Visits}");
+                    }
+                }
+            }
+
+            ArcweaveVisitsState visitsState = new ArcweaveVisitsState(visitDictionary);
+            return visitsState.ToJson();
+        }
+
+        internal void LoadVisits(string visitsSave)
+        {
+            // Load visits
+            ArcweaveVisitsState visits = ArcweaveVisitsState.FromJson(visitsSave);
+
+            ArcweaveVisitsState.VisitsState[] visitStates = visits.GetVisits();
+
+            if (visitStates != null && visitStates.Length > 0)
+            {
+                UnityEngine.Debug.Log($"[Project] Loading {visitStates.Length} visit counts");
+                foreach (var visitState in visitStates)
+                {
+                    var element = ElementWithId(visitState.elementId);
+                    if (element != null)
+                    {
+                        element.Visits = visitState.nVisit;
+                        UnityEngine.Debug.Log($"[Project] Restored visits for element '{element.Title}' (ID: {visitState.elementId}): {visitState.nVisit}");
+                    }
+                    else
+                    {
+                        UnityEngine.Debug.LogWarning($"[Project] Could not find element with ID '{visitState.elementId}' to restore visits");
+                    }
+                }
+            }
+            else
+            {
+                UnityEngine.Debug.Log("[Project] No visit data to restore");
             }
         }
     }

--- a/Assets/Arcweave/Plugin/Runtime/Project/Project.cs
+++ b/Assets/Arcweave/Plugin/Runtime/Project/Project.cs
@@ -22,6 +22,8 @@ namespace Arcweave.Project
         [field: UnityEngine.SerializeReference]
         public List<Variable> Variables { get; private set; }
 
+        [UnityEngine.SerializeField] private string _defaultStartingElementId;
+
         [UnityEngine.SerializeField] private string _startingElementId;
         [System.NonSerialized] private Element _startingElement;
 
@@ -33,6 +35,7 @@ namespace Arcweave.Project
         public Project(string name, Element startingElement, List<Board> boards, List<Component> components, List<Variable> variables) {
             this.name = name;
             this.StartingElement = startingElement;
+            this._defaultStartingElementId = startingElement.Id;
             this.Boards = boards;
             this.components = components;
             Variables = variables;
@@ -44,6 +47,8 @@ namespace Arcweave.Project
         public void Initialize() {
             ResetVariablesToDefaultValues();
             ResetVisits();
+            ResetStartingElement();
+
             foreach ( var board in Boards ) {
                 foreach ( var node in board.Nodes ) {
                     node.InitializeInProject(this);
@@ -58,17 +63,7 @@ namespace Arcweave.Project
 
         ///----------------------------------------------------------------------------------------------
 
-        ///<summary>Returns the number of visits of an element with id.</summary>
-        public int Visits(string id) { return ElementWithId(id).Visits; }
 
-        ///<summary>Reset the number of visits to 0 for all elements.</summary>
-        public void ResetVisits() {
-            foreach ( var board in Boards ) {
-                foreach ( var element in board.Nodes.OfType<Element>() ) {
-                    element.Visits = 0;
-                }
-            }
-        }
 
         ///----------------------------------------------------------------------------------------------
 
@@ -137,6 +132,35 @@ namespace Arcweave.Project
             }
         }
 
+
+        ///---------------------------------------------------------------------------------------------
+
+        public void ResetStartingElement()
+        {
+            if(string.IsNullOrEmpty(_defaultStartingElementId))
+            {
+                return;
+            }
+            StartingElement = ElementWithId(_defaultStartingElementId);
+        }
+
+        ///-------------------------- VISITS --------------------------------------------------------------------------------
+
+        ///<summary>Returns the number of visits of an element with id.</summary>
+        public int Visits(string id) { return ElementWithId(id).Visits; }
+
+        ///<summary>Reset the number of visits to 0 for all elements.</summary>
+        public void ResetVisits()
+        {
+            foreach (var board in Boards)
+            {
+                foreach (var element in board.Nodes.OfType<Element>())
+                {
+                    element.Visits = 0;
+                }
+            }
+        }
+
         internal string SaveVisits()
         {
             var visitDictionary = new Dictionary<string, int>();
@@ -147,7 +171,6 @@ namespace Arcweave.Project
                     if (element.Visits > 0)
                     {
                         visitDictionary[element.Id] = element.Visits;
-                        UnityEngine.Debug.Log($"[Project] Saving visit count for element '{element.Title}' (ID: {element.Id}): {element.Visits}");
                     }
                 }
             }
@@ -185,5 +208,7 @@ namespace Arcweave.Project
                 UnityEngine.Debug.Log("[Project] No visit data to restore");
             }
         }
-    }
-}
+
+    }// end of class
+
+}// end of namespace

--- a/Assets/Arcweave/Plugin/Runtime/Project/Variable.cs
+++ b/Assets/Arcweave/Plugin/Runtime/Project/Variable.cs
@@ -1,3 +1,5 @@
+using System;
+using Unity.VisualScripting;
 using UnityEngine;
 
 namespace Arcweave.Project
@@ -8,7 +10,15 @@ namespace Arcweave.Project
     {
         [field: SerializeField]
         public string Name { get; set; }
-        public object Value { get; set; }
+        private object _value;
+        public object Value 
+        { 
+            get => _value;
+            set 
+            {
+                _value = value;
+            }
+        }
 
         [SerializeField, HideInInspector]
         private string valueSerialized;
@@ -24,7 +34,34 @@ namespace Arcweave.Project
             get => _defaultValue;
             set
             {
-                _defaultValue = value;
+                _defaultValue = null;
+
+                // Create a copy of the value to preserve the original state
+                if (value == null)
+                {
+                    _defaultValue = null;
+                }
+                else
+                {
+                    var type = value.GetType();
+
+                    if (type == typeof(string) || type == typeof(int) || type == typeof(double) || type == typeof(bool))
+                    {
+                        _defaultValue = value;
+                    }
+                    else 
+                    {
+                        // If the value is a reference type it has to implement ICloneable to create a deep copy, otherwise we will lose the default value
+                        if (value is ICloneable cloneable)
+                        {
+                            _defaultValue = cloneable.Clone();
+                        }
+                        else
+                        {
+                            throw new InvalidOperationException($"Default value of type {type.FullName} must implement ICloneable to store a default value.");
+                        }
+                    }
+                }
             }
         }
         
@@ -42,10 +79,13 @@ namespace Arcweave.Project
 
         ///<summary>Reset the variable to its default value.</summary>
         public void ResetToDefaultValue() {
-            if ( Type == typeof(string) ) { this.Value = (string)DefaultValue; }
-            if ( Type == typeof(int) ) { this.Value = (int)DefaultValue; }
-            if ( Type == typeof(double) ) { this.Value = (double)DefaultValue; }
-            if ( Type == typeof(bool) ) { this.Value = (bool)DefaultValue; }
+
+            // Create a copy of the default value to ensure it's not modified
+            if ( Type == typeof(string) ) { this.Value = DefaultValue == null ? null : (string)DefaultValue; }
+            else if ( Type == typeof(int) ) { this.Value = (int)DefaultValue; }
+            else if ( Type == typeof(double) ) { this.Value = (double)DefaultValue; }
+            else if ( Type == typeof(bool) ) { this.Value = (bool)DefaultValue; }
+
         }
 
         private string GetSerializedValue(object value)
@@ -75,7 +115,7 @@ namespace Arcweave.Project
             return "";
         }
 
-        private object DeserializeValue(string stringValue)
+        private object DeserializeValue(string stringValue, bool isDefaultValue)
         {
             if (stringValue.Length == 0)
             {
@@ -83,27 +123,37 @@ namespace Arcweave.Project
             }
             
             var type = stringValue[0];
+            string serializedObject = isDefaultValue ? defaultValueSerialized : valueSerialized;
+
             return type switch
             {
                 'n' => null,
-                's' => valueSerialized[1..],
-                'i' => int.Parse(valueSerialized[1..]),
-                'd' => double.Parse(valueSerialized[1..]),
-                'b' => bool.Parse(valueSerialized[1..]),
+                's' => serializedObject[1..],
+                'i' => int.Parse(serializedObject[1..]),
+                'd' => double.Parse(serializedObject[1..]),
+                'b' => bool.Parse(serializedObject[1..]),
                 _ => default
             };
         }
         
         public void OnBeforeSerialize()
         {
+            /* Clear serialization */
+            valueSerialized = "";
+            defaultValueSerialized = "";
+
             valueSerialized = GetSerializedValue(Value);
             defaultValueSerialized = GetSerializedValue(_defaultValue);
         }
 
         public void OnAfterDeserialize()
         {
-            Value = DeserializeValue(valueSerialized);
-            _defaultValue = DeserializeValue(defaultValueSerialized);
+            /* Clear the content*/
+            _value = null;
+            _defaultValue = null;
+
+            _value = DeserializeValue(valueSerialized, /*isDefaultValue =*/ false);
+            _defaultValue = DeserializeValue(defaultValueSerialized, /*isDefaultValue =*/ true);
         }
     }
 }

--- a/Assets/Arcweave/Plugin/Runtime/Project/Variable.cs
+++ b/Assets/Arcweave/Plugin/Runtime/Project/Variable.cs
@@ -44,7 +44,9 @@ namespace Arcweave.Project
                 {
                     var type = value.GetType();
 
-                    if (type == typeof(string) || type == typeof(int) || type == typeof(double) || type == typeof(bool))
+                    // value types and strings can be directly assigned as they are immutable, but reference types need to be cloned to avoid
+                    // modifying the default value when the variable value changes
+                    if (type == typeof(string) || type.IsValueType)
                     {
                         _defaultValue = value;
                     }
@@ -84,6 +86,7 @@ namespace Arcweave.Project
             else if ( Type == typeof(int) ) { this.Value = (int)DefaultValue; }
             else if ( Type == typeof(double) ) { this.Value = (double)DefaultValue; }
             else if ( Type == typeof(bool) ) { this.Value = (bool)DefaultValue; }
+            else if ( Type == typeof(float) ) { this.Value = (float)DefaultValue; }
 
         }
 
@@ -110,11 +113,15 @@ namespace Arcweave.Project
             {
                 return "b" + value;
             }
+            if (type == typeof(float))
+            {
+                return "f" + value;
+            }
 
             return "";
         }
 
-        private object DeserializeValue(string stringValue, bool isDefaultValue)
+        private object DeserializeValue(string stringValue)
         {
             if (stringValue.Length == 0)
             {
@@ -122,15 +129,15 @@ namespace Arcweave.Project
             }
             
             var type = stringValue[0];
-            string serializedObject = isDefaultValue ? defaultValueSerialized : valueSerialized;
 
             return type switch
             {
                 'n' => null,
-                's' => serializedObject[1..],
-                'i' => int.Parse(serializedObject[1..]),
-                'd' => double.Parse(serializedObject[1..]),
-                'b' => bool.Parse(serializedObject[1..]),
+                's' => stringValue[1..],
+                'i' => int.Parse(stringValue[1..]),
+                'd' => double.Parse(stringValue[1..]),
+                'b' => bool.Parse(stringValue[1..]),
+                'f' => float.Parse(stringValue[1..]),
                 _ => default
             };
         }
@@ -151,8 +158,8 @@ namespace Arcweave.Project
             _value = null;
             _defaultValue = null;
 
-            _value = DeserializeValue(valueSerialized, /*isDefaultValue =*/ false);
-            _defaultValue = DeserializeValue(defaultValueSerialized, /*isDefaultValue =*/ true);
+            _value = DeserializeValue(valueSerialized);
+            _defaultValue = DeserializeValue(defaultValueSerialized);
         }
     }
 }

--- a/Assets/Arcweave/Plugin/Runtime/Project/Variable.cs
+++ b/Assets/Arcweave/Plugin/Runtime/Project/Variable.cs
@@ -1,5 +1,4 @@
 using System;
-using Unity.VisualScripting;
 using UnityEngine;
 
 namespace Arcweave.Project

--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 # Arcweave Plugin for Unity
+![Language](https://img.shields.io/badge/language-C%23-4EAF1A?style=flat-square&logo=csharp&logoColor=FFFFFF&labelColor=4EAF1A)
+![Open Issues](https://img.shields.io/github/issues-raw/arcweave/arcweave-unity-plugin?color=FF0000&style=flat-square&label=open%20issues)
+![License](https://img.shields.io/badge/license-MIT-brightgreen.svg?style=flat-square)
 
 This plugin imports [Arcweave](https://arcweave.com/) projects into Unity. It supports data exported from **Arcweave Project > Export > Engine > Export for Unity** (available to all users) or fetched via Arcweave's web API (available to Team workspaces only).
 
@@ -288,8 +291,11 @@ The root container for an imported Arcweave project. Access via `ArcweaveProject
 | `Variable GetVariable(string name)` | Get Variable object by name |
 | `bool SetVariable(string name, object value)` | Set variable value |
 | `void ResetVariablesToDefaultValues()` | Reset all variables to defaults |
+| `void ResetStartingElement()` | Reset starting element to default |
 | `string SaveVariables()` | Serialize current variable state to JSON |
 | `void LoadVariables(string json)` | Restore variable state from JSON |
+| `string SaveVisits()` | Serialize visit counts to JSON (internal) |
+| `void LoadVisits(string visitsSave)` | Restore visit counts from JSON (internal) |
 | `int Visits(string elementId)` | Get visit count for an element |
 | `void ResetVisits()` | Reset all visit counts to 0 |
 
@@ -563,6 +569,8 @@ Event-driven narrative player (demo helper class).
 |-------|------|-------------|
 | `aw` | ArcweaveProjectAsset | The project to play |
 | `autoStart` | bool | Auto-start on scene load |
+| `saveMode` | SaveMode | Controls when the player automatically saves progress |
+| `saveHandler` | ArcweaveSaveHandler | Optional save handler component to handle save/load events |
 
 #### Events
 
@@ -573,16 +581,28 @@ Event-driven narrative player (demo helper class).
 | `onElementEnter` | `(Element)` | Entered new element |
 | `onElementOptions` | `(Options, Action<int>)` | Multiple choices available |
 | `onWaitInputNext` | `(Action)` | Single path, waiting for continue |
+| `onProjectUpdated` | `(Project)` | Fired when project is updated (e.g., after loading) |
+
 
 #### Methods
 
 | Method | Description |
 |--------|-------------|
 | `void PlayProject()` | Start or restart the narrative |
-| `void Save()` | Save current state to PlayerPrefs |
-| `void Load()` | Load and restore saved state |
+| `void EnsureInitialized()` | Initialize the project if not already initialized |
+| `void RequestSave()` | Requests a save of the current game state |
+| `bool RequestLoad()` | Requests loading of a previously saved game state, returns true if successful |
+| `void ResetVariables()` | Resets all project variables to their default values and clears saved state |
+| `bool HasSave()` | Returns true if a save file exists |
 
----
+# ArcweaveSaveHandler Methods
+
+| Method | Description |
+|--------|-------------|
+| `bool HandleSaveRequest(string elementId, string variables, string visits)` | Handles saving game state |
+| `bool HandleLoadRequest(out string elementId, out string variables, out string visits)` | Handles loading game state |
+| `void ResetSave()` | Clears all saved data |
+| `bool HasSave()` | Returns true if save data exists |
 
 ## Important Notes
 


### PR DESCRIPTION
# Summary
This pull request updates the `ArcweaveDemoScene.unity` scene to support a new save system

**Arcweave Save System Integration:**

* Added a new `ArcweaveSaveHandler` MonoBehaviour to the `ArcweavePlayer` GameObject, and linked it in the player's script component, introducing `saveMode` and `saveHandler` fields for enhanced save functionality. [[1]](diffhunk://#diff-6c2165545f96d11832af5009d1e80d88fb5342849485e0be3e3d58a0c4710cadR200) [[2]](diffhunk://#diff-6c2165545f96d11832af5009d1e80d88fb5342849485e0be3e3d58a0c4710cadL223-R223) [[3]](diffhunk://#diff-6c2165545f96d11832af5009d1e80d88fb5342849485e0be3e3d58a0c4710cadR239-R251)
* fix a problem related to overriding the default value for the variables when deserializing. 
* reset the start element when initializing the project

##  Example
Previously If a player collected a potion and saved, the load process would set the "initial" state of have_potion to true. This effectively "baked" the saved data into the default settings, preventing the `ResetToDefaultValue()` functionality from returning the variable to its original intended state.